### PR TITLE
Fix "'webgpu' has not yet been initialized" error

### DIFF
--- a/src/Handpose/index.js
+++ b/src/Handpose/index.js
@@ -44,7 +44,7 @@ class Handpose extends EventEmitter {
       modelType: this.config?.modelType ?? "full", // use full version of the model by default
       solutionPath: "https://cdn.jsdelivr.net/npm/@mediapipe/hands", // fetch model from mediapipe server
     };
-
+    await tf.ready();
     this.model = await handPoseDetection.createDetector(pipeline, modelConfig);
 
     this.modelReady = true;

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -113,6 +113,7 @@ class DiyNeuralNetwork {
    * @param {*} callback
    */
   init(callback) {
+    tf.setBackend("webgl");
     // check if the a static model should be built based on the inputs and output properties
     if (this.options.noTraining === true) {
       this.createLayersNoTraining();

--- a/src/PoseDetection/index.js
+++ b/src/PoseDetection/index.js
@@ -78,10 +78,9 @@ class PoseDetection extends EventEmitter {
           bodyPoseDetection.movenet.modelType.MULTIPOSE_LIGHTNING;
     }
     // Load the detector model
-    await tf.setBackend("webgl");
+    await tf.ready();
     this.model = await bodyPoseDetection.createDetector(pipeline, modelConfig);
     this.modelReady = true;
-
     if (this.video) {
       this.predict();
     }


### PR DESCRIPTION
- add `await tf.ready()` to handpose 
- add `await tf.ready()` to pose-detection 
- add `tf.setBackend("webgl")` to neuralNetwork

Hi @shiffman, I think the problem [here](https://github.com/ml5js/ml5-next-gen/pull/31#issuecomment-1677575919) is caused by tf.js using webgpu, instead of webgl, as the default backend on some browsers and machines. (I tried running the neural network example in both Chrome and Firefox and the error only occurred in Chrome. Firefox doesn't support webgpu yet.)

I am not exactly sure how the dependencies from pose-detection trigger this error, but I found a solution. We have to call `await tf.ready();`, [more info here](https://js.tensorflow.org/api/latest/?_gl=1*jwegjo*_ga*MTkzNTU5MTk0OS4xNjg1Mzg5MDIz*_ga_W0YLR4190T*MTY5MjA0MTg2Mi4xNC4wLjE2OTIwNDE4NjUuMC4wLjA.#ready), before calling any other tensorflow.js functions because unlike webgl, setting webgpu backend is an asynchronous task. 

I have added `await tf.ready();` to all other models; however, using the webgpu backend for neuralNetwork caused another problem, which seems like a much deeper issue to resolve:
<img width="380" alt="error" src="https://github.com/ml5js/ml5-next-gen/assets/93690311/ec7b6f22-7539-4edf-bdf4-a2ab62c0420b">
I think the best solution, for now, is to force neuralNetwork to use the original WebGL backend by calling `tf.setBackend("webgl");`

Just some other random thoughts:

I was switching between the webgl an webgpu backends and found that the frame rate varied depending on the model and the computer being used. I think it might be helpful to add an option argument to tf.js-based models, allowing more advanced users to manually set the backend and fine-tune their projects.

```javascript
let options = {
  backend: "webgl"
}
let handpose = ml5.handpose(options);
```
