### PR TITLE
add production build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js --mode production",
-    "develop": "webpack --config webpack.config.js",
     "start": "webpack serve --config webpack.config.js --mode development",
     "format": "prettier --write \"**/*.js\""
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js --env production",
+    "build": "webpack --config webpack.config.js --mode production",
     "develop": "webpack --config webpack.config.js",
-    "start": "webpack serve --config webpack.config.js",
+    "start": "webpack serve --config webpack.config.js --mode development",
     "format": "prettier --write \"**/*.js\""
   },
   "keywords": [
@@ -23,7 +23,8 @@
     "prettier": "2.8.8",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "webpack-merge": "^5.9.0"
   },
   "dependencies": {
     "@mediapipe/face_mesh": "^0.4.1633559619",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,37 @@
 {
   "name": "ml5-next-gen",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "A friendly machine learning library for the web.",
+  "main": "dist/ml5.js",
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "webpack --config webpack.config.js --mode production",
     "start": "webpack serve --config webpack.config.js --mode development",
     "format": "prettier --write \"**/*.js\""
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "ML5"
   ],
   "author": "ml5",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ml5js/ml5-next-gen"
+    "url": "git+https://github.com/ml5js/ml5-next-gen.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ml5js/ml5-next-gen/issues"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.5.3",
     "prettier": "2.8.8",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "^4.15.1",
-    "webpack-merge": "^5.9.0"
+    "webpack-dev-server": "^4.15.1"
   },
+  "homepage": "https://github.com/ml5js/ml5-next-gen#readme",
   "dependencies": {
     "@mediapipe/face_mesh": "^0.4.1633559619",
     "@mediapipe/hands": "^0.4.1675469240",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,44 +1,66 @@
 const { resolve } = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { merge } = require("webpack-merge");
 
-module.exports = function (env, argv) {
-  return {
-    context: __dirname,
-    entry: "./src/index.js",
+const commonConfig = {
+  context: __dirname,
+  entry: "./src/index.js",
+  output: {
+    filename: "ml5.js",
+    path: resolve(__dirname, "dist"),
+    library: {
+      name: "ml5",
+      type: "umd",
+      export: "default",
+    },
+  },
+};
 
-    mode: env.production ? "production" : "development",
-    devtool: env.production ? "source-map" : "inline-source-map",
-    output: {
-      filename: "ml5.js",
-      path: resolve(__dirname, "dist"),
-      publicPath: "/dist/",
-      library: {
-        name: "ml5",
-        type: "umd",
-        export: "default",
+const developmentConfig = {
+  mode: "development",
+  devtool: "inline-source-map",
+  output: {
+    publicPath: "/dist/",
+  },
+  devServer: {
+    port: 8080,
+    allowedHosts: "all",
+    static: [
+      {
+        directory: resolve(__dirname, "dist"),
+        publicPath: "/dist",
+        watch: true,
       },
-    },
-    devServer: {
-      port: 8080,
-      allowedHosts: "all",
-      static: [
-        {
-          directory: resolve(__dirname, "dist"),
-          publicPath: "/dist",
-          watch: true,
-        },
-        {
-          directory: resolve(__dirname, "examples"),
-          publicPath: "/examples",
-          watch: true,
-        },
-      ],
-      open: "/examples",
-    },
-    plugins: [
-      new HtmlWebpackPlugin({
-        title: "ml5",
-      }),
+      {
+        directory: resolve(__dirname, "examples"),
+        publicPath: "/examples",
+        watch: true,
+      },
     ],
-  };
+    open: "/examples",
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: "ml5",
+    }),
+  ],
+};
+
+const productionConfig = {
+  mode: "production",
+  devtool: "source-map",
+  output: {
+    publicPath: "/",
+  },
+};
+
+module.exports = function (env, args) {
+  switch (args.mode) {
+    case "development":
+      return merge(commonConfig, developmentConfig);
+    case "production":
+      return merge(commonConfig, productionConfig);
+    default:
+      throw new Error("No matching configuration was found!");
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ webpack-dev-server@^4.15.1:
     webpack-dev-middleware "^5.3.1"
     ws "^8.13.0"
 
-webpack-merge@^5.7.3:
+webpack-merge@^5.7.3, webpack-merge@^5.9.0:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.9.0.tgz#dc160a1c4cf512ceca515cc231669e9ddb133826"
   integrity sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==


### PR DESCRIPTION
This PR refactors the WebPack config file and adds a production build option.
Run `yarn run build` to create a production build of the library in the `dist` folder.
