### PR TITLE
Add blazepose

### DIFF
--- a/examples/Bodypose-blazepose-keypoints/index.html
+++ b/examples/Bodypose-blazepose-keypoints/index.html
@@ -1,0 +1,19 @@
+<!--
+ Copyright (c) 2018-2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ml5.js Bodypose Blazepose Detection Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/Bodypose-blazepose-keypoints/sketch.js
+++ b/examples/Bodypose-blazepose-keypoints/sketch.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+let video;
+let bodypose;
+let poses = [];
+
+function preload() {
+  //Load the handpose model.
+  bodypose = ml5.bodypose("BlazePose");
+}
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+
+  // Start detecting poses in the webcam video
+  bodypose.detectStart(video, gotPoses);
+}
+
+function draw() {
+  console.log(poses);
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < pose.keypoints.length; j++) {
+      let keypoint = pose.keypoints[j];
+      fill(0, 255, 0);
+      noStroke();
+      circle(keypoint.x, keypoint.y, 10);
+    }
+  }
+}
+
+// Callback function for when bodypose outputs data
+function gotPoses(results) {
+  // Save the output to the poses variable
+  poses = results;
+}

--- a/src/Bodypose/index.js
+++ b/src/Bodypose/index.js
@@ -42,17 +42,16 @@ class Bodypose {
 
   /**
    * Creates Bodypose.
-   * @param {string} modelName - Specify a model to use, "MoveNet" or "BlazePose"
+   * @param {string} modelName - Specify a model to use, "MoveNet" or "BlazePose". Default: "MoveNet".
    * @param {configOptions} options - An object describing a model accuracy and performance.
    * @param {function} callback  - A function to run once the model has been loaded.
    * @private
    */
-  constructor(modelName, options, callback) {
+  constructor(modelName = "MoveNet", options, callback) {
     // for compatibility with p5's preload()
     if (this.p5PreLoadExists()) window._incrementPreload();
 
-    this.modelName = modelName ?? "MoveNet";
-
+    this.modelName = modelName;
     this.model = null;
     this.config = options;
     this.runtimeConfig = {};

--- a/src/Bodypose/index.js
+++ b/src/Bodypose/index.js
@@ -74,7 +74,29 @@ class Bodypose {
     let pipeline;
     let modelConfig;
 
-    if (this.modelName === "MoveNet") {
+    if (this.modelName === "BlazePose") {
+      pipeline = poseDetection.SupportedModels.BlazePose;
+      //Set the config to user defined or default values
+      modelConfig = {
+        runtime: this.config.runtime ?? "mediapipe",
+        enableSmoothing: this.config.enableSmoothing ?? true,
+        enableSegmentation: this.config.enableSegmentation ?? false,
+        smoothSegmentation: this.config.smoothSegmentation ?? true,
+        modelType: this.config.smoothSegmentation ?? "full",
+        solutionPath:
+          this.config.solutionPath ??
+          "https://cdn.jsdelivr.net/npm/@mediapipe/pose",
+        detectorModelUrl: this.config?.detectorModelUrl,
+        landmarkModelUrl: this.config?.landmarkModelUrl,
+      };
+
+      this.runtimeConfig.flipHorizontal = this.config.flipHorizontal ?? false;
+    } else {
+      if (this.modelName !== "MoveNet") {
+        console.warn(
+          `Expect model name to be "MoveNet" or "BlazePose", but got "${this.modelName}". Using "MoveNet" instead.`
+        );
+      }
       pipeline = poseDetection.SupportedModels.MoveNet;
       //Set the config to user defined or default values
       modelConfig = {
@@ -100,23 +122,6 @@ class Bodypose {
           modelConfig.modelType =
             poseDetection.movenet.modelType.MULTIPOSE_LIGHTNING;
       }
-    } else if (this.modelName === "BlazePose") {
-      pipeline = poseDetection.SupportedModels.BlazePose;
-      //Set the config to user defined or default values
-      modelConfig = {
-        runtime: this.config.runtime ?? "mediapipe",
-        enableSmoothing: this.config.enableSmoothing ?? true,
-        enableSegmentation: this.config.enableSegmentation ?? false,
-        smoothSegmentation: this.config.smoothSegmentation ?? true,
-        modelType: this.config.smoothSegmentation ?? "full",
-        solutionPath:
-          this.config.solutionPath ??
-          "https://cdn.jsdelivr.net/npm/@mediapipe/pose",
-        detectorModelUrl: this.config?.detectorModelUrl,
-        landmarkModelUrl: this.config?.landmarkModelUrl,
-      };
-
-      this.runtimeConfig.flipHorizontal = this.config.flipHorizontal ?? false;
     }
 
     // Load the detector model

--- a/src/Bodypose/index.js
+++ b/src/Bodypose/index.js
@@ -16,22 +16,33 @@ import { mediaReady } from "../utils/imageUtilities";
 
 class Bodypose {
   /**
-   * An object for configuring MoveNet options.
+   * An object for configuring Bodypose options.
    * @typedef {Object} configOptions
-   * @property {string} modelType - Optional. specify what model variant to load from. Default: "MULTIPOSE_LIGHTNING".
+   * @property {string} modelType - Optional. specify what model variant to load from.
    * @property {boolean} enableSmoothing - Optional. Whether to use temporal filter to smooth keypoints across frames. Default: true.
+   *
+   * Only for when using MoveNet model
    * @property {number} minPoseScore - Optional. The minimum confidence score for a pose to be detected. Default: 0.25.
    * @property {number} multiPoseMaxDimension - Optional. The target maximum dimension to use as the input to the multi-pose model. Must be a mutiple of 32. Default: 256.
    * @property {boolean} enableTracking - Optional. Track each person across the frame with a unique ID. Default: true.
    * @property {string} trackerType - Optional. Specify what type of tracker to use. Default: "boundingBox".
    * @property {Object} trackerConfig - Optional. Specify tracker configurations. Use tf.js settings by default.
    *
-   * //For using custom or offline models
-   * @property {string} modelUrl - Optional. A The file path or URL to the model.
+   * Only for when using BlazePose model
+   * @property {string} runtime - Optional. Either "tfjs" or "mediapipe". Default: "mediapipe"
+   * @property {boolean} enableSegmentation - Optional. A boolean indicating whether to generate the segmentation mask.
+   * @property {boolean} smoothSegmentation - Optional. whether to filters segmentation masks across different input images to reduce jitter.
+   *
+   * For using custom or offline models
+   * @property {string} modelUrl - Optional. The file path or URL to the MoveNet model.
+   * @property {string} solutionPath - Optional. The file path or URL to the mediaPipe BlazePose model.
+   * @property {string} detectorModelUrl - Optional. The file path or URL to the tfjs BlazePose detector model.
+   * @property {string}landmarkModelUrl - Optional. The file path or URL to the tfjs BlazePose landmark model.
    */
 
   /**
    * Creates Bodypose.
+   * @param {string} modelName - Specify a model to use, "MoveNet" or "BlazePose"
    * @param {configOptions} options - An object describing a model accuracy and performance.
    * @param {function} callback  - A function to run once the model has been loaded.
    * @private
@@ -223,13 +234,14 @@ class Bodypose {
    */
   addKeypoints(hands) {
     const result = hands.map((hand) => {
-      for (let i = 0; i < hand.keypoints.length; i++) {
-        let keypoint = hand.keypoints[i];
+      hand.keypoints.forEach((keypoint) => {
         hand[keypoint.name] = {
           x: keypoint.x,
           y: keypoint.y,
+          score: keypoint.score,
         };
-      }
+        if (keypoint.z) hand[keypoint.name].z = keypoint.z;
+      });
       return hand;
     });
     return result;


### PR DESCRIPTION
This PR adds the BlazePose model to BodyPose. 
The changes are as follows:
- add a third parameter, modelName, to `ml5.bodypose` which specifics the underlying model to use. It defaults to MoveNet if no model name is provided.
```javascript
ml5.bodypose("BlazePose", options, callback);
//or 
ml5.bodypose("MoveNet", options, callback);
```
- update config filtering based on which underlying model is being used. 
- update `addKeypoints` function so it adds the z values to the named keypoints (when using BlazePose).
- add a simple example for using bodypose in BlazePose mode.