### PR TITLE
Improve comments in example sketches

### DIFF
--- a/examples/Bodypose-blazepose-keypoints/sketch.js
+++ b/examples/Bodypose-blazepose-keypoints/sketch.js
@@ -8,7 +8,7 @@ let bodypose;
 let poses = [];
 
 function preload() {
-  //Load the bodypose model.
+  // Load the bodypose model
   bodypose = ml5.bodypose("BlazePose");
 }
 

--- a/examples/Bodypose-blazepose-keypoints/sketch.js
+++ b/examples/Bodypose-blazepose-keypoints/sketch.js
@@ -8,7 +8,7 @@ let bodypose;
 let poses = [];
 
 function preload() {
-  //Load the handpose model.
+  //Load the bodypose model.
   bodypose = ml5.bodypose("BlazePose");
 }
 

--- a/examples/Bodypose-keypoints/sketch.js
+++ b/examples/Bodypose-keypoints/sketch.js
@@ -8,7 +8,7 @@ let bodypose;
 let poses = [];
 
 function preload() {
-  //Load the handpose model.
+  //Load the bodypose model.
   bodypose = ml5.bodypose();
 }
 
@@ -33,7 +33,7 @@ function draw() {
     let pose = poses[i];
     for (let j = 0; j < pose.keypoints.length; j++) {
       let keypoint = pose.keypoints[j];
-      // Only draw a circle if the keypoint's confidence is bigger than 0.2
+      // Only draw a circle if the keypoint's confidence is bigger than 0.1
       if (keypoint.score > 0.1) {
         fill(0, 255, 0);
         noStroke();

--- a/examples/Bodypose-keypoints/sketch.js
+++ b/examples/Bodypose-keypoints/sketch.js
@@ -8,7 +8,7 @@ let bodypose;
 let poses = [];
 
 function preload() {
-  //Load the bodypose model.
+  // Load the bodypose model
   bodypose = ml5.bodypose();
 }
 

--- a/examples/Facemesh-keypoints/index.html
+++ b/examples/Facemesh-keypoints/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Facemesh-keypoints/sketch.js
+++ b/examples/Facemesh-keypoints/sketch.js
@@ -43,5 +43,4 @@ function draw() {
 function gotFaces(results) {
   // Save the output to the faces variable
   faces = results;
-  //console.log(faces);
 }

--- a/examples/Facemesh-parts/index.html
+++ b/examples/Facemesh-parts/index.html
@@ -1,3 +1,9 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Facemesh-parts/sketch.js
+++ b/examples/Facemesh-parts/sketch.js
@@ -29,7 +29,12 @@ function draw() {
 
   if (faces.length > 0 && faces[0].lips) {
     fill(0, 255, 0);
-    rect(faces[0].lips.x, faces[0].lips.y, faces[0].lips.width, faces[0].lips.height);
+    rect(
+      faces[0].lips.x,
+      faces[0].lips.y,
+      faces[0].lips.width,
+      faces[0].lips.height
+    );
   }
 
   drawPartsKeypoints();
@@ -51,5 +56,4 @@ function drawPartsKeypoints() {
 function gotFaces(results) {
   // Save the output to the faces variable
   faces = results;
-  //console.log(faces);
 }

--- a/examples/Facemesh-single-image/index.html
+++ b/examples/Facemesh-single-image/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Facemesh-single-image/sketch.js
+++ b/examples/Facemesh-single-image/sketch.js
@@ -40,5 +40,4 @@ function draw() {
 function gotFaces(results) {
   // Save the output to the faces variable
   faces = results;
-  //console.log(faces);
 }

--- a/examples/Handpose-keypoints/index.html
+++ b/examples/Handpose-keypoints/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 22023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Handpose-keypoints/index.html
+++ b/examples/Handpose-keypoints/index.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (c) 22023 ml5
+ Copyright (c) 2023 ml5
  
  This software is released under the MIT License.
  https://opensource.org/licenses/MIT

--- a/examples/Handpose-keypoints/sketch.js
+++ b/examples/Handpose-keypoints/sketch.js
@@ -8,7 +8,7 @@ let video;
 let hands = [];
 
 function preload() {
-  // Load the handpose model.
+  // Load the handpose model
   handpose = ml5.handpose();
 }
 

--- a/examples/Handpose-parts/index.html
+++ b/examples/Handpose-parts/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Handpose-parts/sketch.js
+++ b/examples/Handpose-parts/sketch.js
@@ -11,7 +11,7 @@ let hands = [];
 let pinch = 0;
 
 function preload() {
-  // Load the handpose model.
+  // Load the handpose model
   handpose = ml5.handpose();
 }
 
@@ -21,7 +21,7 @@ function setup() {
   video = createCapture(VIDEO);
   video.size(width, height);
   video.hide();
-  // start detecting hands from the webcam video
+  // Start detecting hands from the webcam video
   handpose.detectStart(video, gotHands);
 }
 
@@ -51,7 +51,7 @@ function draw() {
 
 // Callback function for when handpose outputs data
 function gotHands(results) {
-  // save the output to the hands variable
+  // Save the output to the hands variable
   hands = results;
   console.log(hands);
 }

--- a/examples/Handpose-single-image/index.html
+++ b/examples/Handpose-single-image/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Handpose-single-image/sketch.js
+++ b/examples/Handpose-single-image/sketch.js
@@ -8,9 +8,9 @@ let video;
 let hands = [];
 
 function preload() {
-  //load the image to be detected
+  // Load the image to be detected
   img = loadImage("hand.jpg");
-  // Load the handpose model.
+  // Load the handpose model
   handpose = ml5.handpose();
 }
 

--- a/examples/Handpose-start-stop/index.html
+++ b/examples/Handpose-start-stop/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/Handpose-start-stop/sketch.js
+++ b/examples/Handpose-start-stop/sketch.js
@@ -9,7 +9,7 @@ let hands = [];
 let isDetecting = false;
 
 function preload() {
-  // Load the handpose model.
+  // Load the handpose model
   handpose = ml5.handpose();
 }
 
@@ -46,12 +46,12 @@ function draw() {
   }
 }
 
-//toggle detection when mouse is pressed
+// Toggle detection when mouse is pressed
 function mousePressed() {
   toggleDetection();
 }
 
-// call this function to start and stop detection
+// Call this function to start and stop detection
 function toggleDetection() {
   if (isDetecting) {
     handpose.detectStop();
@@ -64,6 +64,6 @@ function toggleDetection() {
 
 // Callback function for when handpose outputs data
 function gotHands(results) {
-  // save the output to the hands variable
+  // Save the output to the hands variable
   hands = results;
 }

--- a/examples/NeuralNetwork-color-classifier/index.html
+++ b/examples/NeuralNetwork-color-classifier/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/NeuralNetwork-color-classifier/sketch.js
+++ b/examples/NeuralNetwork-color-classifier/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 // Step 1: load data or create some data
 let data = [
   { r: 255, g: 0, b: 0, color: "red-ish" },

--- a/examples/NeuralNetwork-mouse-gesture/index.html
+++ b/examples/NeuralNetwork-mouse-gesture/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/NeuralNetwork-mouse-gesture/sketch.js
+++ b/examples/NeuralNetwork-mouse-gesture/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 // Step 1: load data or create some data
 let data = [
   { x: 0.99, y: 0.02, label: "right" },

--- a/examples/NeuroEvolution-flappy-bird/bird.js
+++ b/examples/NeuroEvolution-flappy-bird/bird.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Bird {
   constructor(brain) {
     if (brain) {

--- a/examples/NeuroEvolution-flappy-bird/index.html
+++ b/examples/NeuroEvolution-flappy-bird/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/NeuroEvolution-flappy-bird/pipe.js
+++ b/examples/NeuroEvolution-flappy-bird/pipe.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Pipe {
   constructor() {
     this.spacing = 100;

--- a/examples/NeuroEvolution-flappy-bird/sketch.js
+++ b/examples/NeuroEvolution-flappy-bird/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 let birds = [];
 let pipes = [];
 

--- a/examples/NeuroEvolution-sensors/creature.js
+++ b/examples/NeuroEvolution-sensors/creature.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Creature {
   constructor(x, y, brain) {
     this.position = createVector(x, y);

--- a/examples/NeuroEvolution-sensors/food.js
+++ b/examples/NeuroEvolution-sensors/food.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Food {
   constructor() {
     this.position = createVector(random(width), random(height));

--- a/examples/NeuroEvolution-sensors/index.html
+++ b/examples/NeuroEvolution-sensors/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/NeuroEvolution-sensors/sensor.js
+++ b/examples/NeuroEvolution-sensors/sensor.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Sensor {
   constructor(v) {
     this.v = v.copy();

--- a/examples/NeuroEvolution-sensors/sketch.js
+++ b/examples/NeuroEvolution-sensors/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 let bloops = [];
 let timeSlider;
 let restartButton;

--- a/examples/NeuroEvolution-steering/creature.js
+++ b/examples/NeuroEvolution-steering/creature.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Creature {
   constructor(x, y, brain) {
     this.position = createVector(x, y);

--- a/examples/NeuroEvolution-steering/glow.js
+++ b/examples/NeuroEvolution-steering/glow.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 class Glow {
   constructor() {
     this.xoff = 0;

--- a/examples/NeuroEvolution-steering/index.html
+++ b/examples/NeuroEvolution-steering/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/NeuroEvolution-steering/sketch.js
+++ b/examples/NeuroEvolution-steering/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 let creatures = [];
 let timeSlider;
 let lifeSpan = 250; // How long should each generation live

--- a/examples/Sentiment/index.html
+++ b/examples/Sentiment/index.html
@@ -1,3 +1,10 @@
+<!--
+ Copyright (c) 2023 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
 <html>
   <head>
     <title>ml5 - Sentiment</title>

--- a/examples/Sentiment/sketch.js
+++ b/examples/Sentiment/sketch.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 let sentiment;
 let statusEl; // to display model loading status
 let submitBtn;
@@ -9,14 +14,14 @@ function setup() {
   // initialize sentiment analysis model
   sentiment = ml5.sentiment("movieReviews", modelReady);
 
-  // setup the html environment
+  // setup the html dom elements
   statusEl = createP("Loading Model...");
   inputBox = createInput("Today is the happiest day and is full of rainbows!");
   inputBox.attribute("size", "75");
   submitBtn = createButton("submit");
   sentimentResult = createP("Sentiment score:");
 
-  // predicting the sentiment on mousePressed()
+  // predicting the sentiment when submit button is pressed
   submitBtn.mousePressed(getSentiment);
 }
 
@@ -31,8 +36,8 @@ function getSentiment() {
   sentimentResult.html("Sentiment score: " + prediction.score);
 }
 
+// a callback function that is called when model is ready
 function modelReady() {
-  // model is ready
   statusEl.html("Model loaded");
 }
 


### PR DESCRIPTION
This PR has no functional changes and mostly modifies comments in the example sketches.
- Format the inline comments in the example sketches to keep them consistent
- Fix a few typos in the comments of BodyPose's examples
- Rephrase a few comments in Sentiment's example
- Add copyright and license headers to the documents that didn't have them