### PR TITLE
Extract common logic for detectStart and detectStop into a helper class

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -8,8 +8,9 @@ BodyPose
 Ported from pose-detection at Tensorflow.js
 */
 
-import * as tf from "@tensorflow/tfjs";
 import * as poseDetection from "@tensorflow-models/pose-detection";
+import * as tf from "@tensorflow/tfjs";
+import ImageDetector from "../ImageDetector";
 import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
 import { mediaReady } from "../utils/imageUtilities";
@@ -55,13 +56,6 @@ class BodyPose {
     this.model = null;
     this.config = options;
     this.runtimeConfig = {};
-    this.detectMedia = null;
-    this.detectCallback = null;
-
-    // flags for detectStart() and detectStop()
-    this.detecting = false; // true when detection loop is running
-    this.signalStop = false; // Signal to stop the loop
-    this.prevCall = ""; // Track previous call to detectStart() or detectStop()
 
     this.ready = callCallback(this.loadModel(), callback);
   }
@@ -129,105 +123,23 @@ class BodyPose {
     this.model = await poseDetection.createDetector(pipeline, modelConfig);
 
     // for compatibility with p5's preload()
-    if (this.p5PreLoadExists) window._decrementPreload();
+    if (this.p5PreLoadExists()) window._decrementPreload();
 
     return this;
   }
 
   /**
-   * A callback function that handles the pose detection results.
-   * @callback gotPoses
-   * @param {Array} results - An array of objects containing poses.
-   */
-
-  /**
    * Asynchronously outputs a single pose prediction result when called.
-   * @param {*} media - An HMTL or p5.js image, video, or canvas element to run the prediction on.
-   * @param {gotPoses} callback - A callback function to handle the predictions.
+   * @param {*} media - An HTML or p5.js image, video, or canvas element to run the prediction on.
    * @returns {Promise<Array>} an array of poses.
    */
-  async detect(...inputs) {
-    //Parse out the input parameters
-    const argumentObject = handleArguments(...inputs);
-    argumentObject.require(
-      "image",
-      "An html or p5.js image, video, or canvas element argument is required for detect()."
-    );
-    const { image, callback } = argumentObject;
-
-    await mediaReady(image, false);
+  async detect(media) {
+    await mediaReady(media, false);
     const predictions = await this.model.estimatePoses(
-      image,
+      media,
       this.runtimeConfig
     );
-    let result = predictions;
-    result = this.addKeypoints(result);
-    if (typeof callback === "function") callback(result);
-    return result;
-  }
-
-  /**
-   * Repeatedly outputs pose predictions through a callback function.
-   * Calls the internal detectLoop() function.
-   * @param {*} media - An HMTL or p5.js image, video, or canvas element to run the prediction on.
-   * @param {gotPoses} callback - A callback function to handle the predictions.
-   * @returns {Promise<Array>} an array of predictions.
-   */
-  detectStart(...inputs) {
-    // Parse out the input parameters
-    const argumentObject = handleArguments(...inputs);
-    argumentObject.require(
-      "image",
-      "An html or p5.js image, video, or canvas element argument is required for detectStart()."
-    );
-    argumentObject.require(
-      "callback",
-      "A callback function argument is required for detectStart()."
-    );
-    this.detectMedia = argumentObject.image;
-    this.detectCallback = argumentObject.callback;
-
-    this.signalStop = false;
-    if (!this.detecting) {
-      this.detecting = true;
-      this.detectLoop();
-    }
-    if (this.prevCall === "start") {
-      console.warn(
-        "detectStart() was called more than once without calling detectStop(). The lastest detectStart() call will be used and the previous calls will be ignored."
-      );
-    }
-    this.prevCall = "start";
-  }
-
-  /**
-   * Internal function that calls estimatePoses in a loop
-   * Can be started by detectStart() and terminated by detectStop()
-   * @private
-   */
-  async detectLoop() {
-    await mediaReady(this.detectMedia, false);
-    while (!this.signalStop) {
-      const predictions = await this.model.estimatePoses(
-        this.detectMedia,
-        this.runtimeConfig
-      );
-      let result = predictions;
-      result = this.addKeypoints(result);
-      this.detectCallback(result);
-      // wait for the frame to update
-      await tf.nextFrame();
-    }
-    this.detecting = false;
-    this.signalStop = false;
-  }
-
-  /**
-   * Stops the detection loop before next detection loop runs.
-   */
-  detectStop() {
-    if (this.detecting) this.signalStop = true;
-    this.prevCall = "stop";
+    return this.addKeypoints(predictions);
   }
 
   /**
@@ -268,12 +180,12 @@ class BodyPose {
 
 /**
  * Factory function that returns a BodyPose instance.
- * @returns {BodyPose} A BodyPose instance.
+ * @returns {ImageDetector} A BodyPose instance.
  */
 const bodyPose = (...inputs) => {
   const { string, options = {}, callback } = handleArguments(...inputs);
   const instance = new BodyPose(string, options, callback);
-  return instance;
+  return new ImageDetector(instance);
 };
 
 export default bodyPose;

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -10,16 +10,19 @@
 
 import * as tf from "@tensorflow/tfjs";
 import * as faceLandmarksDetection from "@tensorflow-models/face-landmarks-detection";
+import ImageDetector from "../ImageDetector";
 import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
-import { mediaReady } from "../utils/imageUtilities";
 
+/**
+ * @implements {SpecificDetectorImplementation}
+ */
 class FaceMesh {
   /**
    * An options object to configure FaceMesh settings
    * @typedef {Object} configOptions
-   * @property {number} maxFacess - The maximum number of faces to detect. Defaults to 2.
-   * @property {boolean} refineLandmarks - Refine the ladmarks. Defaults to false.
+   * @property {number} maxFaces - The maximum number of faces to detect. Defaults to 2.
+   * @property {boolean} refineLandmarks - Refine the landmarks. Defaults to false.
    * @property {boolean} flipHorizontal - Flip the result horizontally. Defaults to false.
    * @property {string} runtime - The runtime to use. "mediapipe"(default) or "tfjs".
    *
@@ -41,13 +44,6 @@ class FaceMesh {
     this.model = null;
     this.config = options;
     this.runtimeConfig = {};
-    this.detectMedia = null;
-    this.detectCallback = null;
-
-    // flags for detectStart() and detectStop()
-    this.detecting = false; // true when detection loop is running
-    this.signalStop = false; // true when detectStop() is called and detecting is true
-    this.prevCall = ""; // "start" or "stop", used for giving warning messages with detectStart() is called twice in a row
 
     this.ready = callCallback(this.loadModel(), callback);
   }
@@ -78,99 +74,22 @@ class FaceMesh {
     );
 
     // for compatibility with p5's preload()
-    if (this.p5PreLoadExists) window._decrementPreload();
+    if (this.p5PreLoadExists()) window._decrementPreload();
 
     return this;
   }
 
   /**
    * Asynchronously output a single face prediction result when called
-   * @param {*} [media] - An HMTL or p5.js image, video, or canvas element to run the prediction on.
-   * @param {function} [callback] - A callback function to handle the predictions.
+   * @param {*} [media] - An HTML or p5.js image, video, or canvas element to run the prediction on.
    * @returns {Promise<Array>} an array of predictions.
    */
-  async detect(...inputs) {
-    // Parse out the input parameters
-    const argumentObject = handleArguments(...inputs);
-    argumentObject.require(
-      "image",
-      "An html or p5.js image, video, or canvas element argument is required for detect()."
-    );
-    const { image, callback } = argumentObject;
-
-    await mediaReady(image, false);
+  async detect(media) {
     const predictions = await this.model.estimateFaces(
-      image,
+      media,
       this.runtimeConfig
     );
-    let result = predictions;
-    result = this.addKeypoints(result);
-    if (typeof callback === "function") callback(result);
-    return result;
-  }
-
-  /**
-   * Repeatedly output face predictions through a callback function
-   * @param {*} [media] - An HMTL or p5.js image, video, or canvas element to run the prediction on.
-   * @param {function} [callback] - A callback function to handle the predictions.
-   * @returns {Promise<Array>} an array of predictions.
-   */
-  detectStart(...inputs) {
-    // Parse out the input parameters
-    const argumentObject = handleArguments(...inputs);
-    argumentObject.require(
-      "image",
-      "An html or p5.js image, video, or canvas element argument is required for detectStart()."
-    );
-    argumentObject.require(
-      "callback",
-      "A callback function argument is required for detectStart()."
-    );
-    this.detectMedia = argumentObject.image;
-    this.detectCallback = argumentObject.callback;
-
-    this.signalStop = false;
-    if (!this.detecting) {
-      this.detecting = true;
-      this.detectLoop();
-    }
-    if (this.prevCall === "start") {
-      console.warn(
-        "detectStart() was called more than once without calling detectStop(). The lastest detectStart() call will be used and the previous calls will be  ignored."
-      );
-    }
-    this.prevCall = "start";
-  }
-
-  /**
-   * Stop the detection loop before next detection loop runs.
-   */
-  detectStop() {
-    if (this.detecting) this.signalStop = true;
-    this.prevCall = "stop";
-  }
-
-  /**
-   * Internal function to call estimateFaces in a loop
-   * Can be started by detectStart() and terminated by detectStop()
-   *
-   * @private
-   */
-  async detectLoop() {
-    await mediaReady(this.detectMedia, false);
-    while (!this.signalStop) {
-      const predictions = await this.model.estimateFaces(
-        this.detectMedia,
-        this.runtimeConfig
-      );
-      let result = predictions;
-      result = this.addKeypoints(result);
-      this.detectCallback(result);
-      // wait for the frame to update
-      await tf.nextFrame();
-    }
-    this.detecting = false;
-    this.signalStop = false;
+    return this.addKeypoints(predictions);
   }
 
   /**
@@ -265,12 +184,12 @@ class FaceMesh {
 
 /**
  * Factory function that returns a FaceMesh instance
- * @returns {Object} A new faceMesh instance
+ * @returns {ImageDetector} A new faceMesh instance
  */
 const faceMesh = (...inputs) => {
   const { options = {}, callback } = handleArguments(...inputs);
   const instance = new FaceMesh(options, callback);
-  return instance;
+  return new ImageDetector(instance);
 };
 
 export default faceMesh;

--- a/src/ImageDetector/index.js
+++ b/src/ImageDetector/index.js
@@ -1,0 +1,162 @@
+import * as tf from '@tensorflow/tfjs';
+import handleArguments from '../utils/handleArguments';
+import { mediaReady } from '../utils/imageUtilities';
+
+/**
+ * @typedef {Object} SpecificDetectorImplementation
+ *
+ * @property {Promise<boolean>} ready - lets the parent detector know that the
+ * specific implementation is ready.
+ *
+ * @property {(input: tf.Tensor3D) => Promise<Array>} detect - core detection method.
+ * the ImageDetector will call the `detect` method of the specific implementation.
+ * It should accept a TensorFlow tensor?? or an image??
+ * And return an array of detections??
+ */
+
+/**
+ * Helper class for handling the public API of detector models (facemesh, etc.)
+ * Exposes the public methods for single and continuous detection.
+ * Executes the detection using whatever model is passed to the constructor.
+ */
+export default class ImageDetector {
+
+  /**
+   * @param {SpecificDetectorImplementation} specificImplementation
+   */
+  constructor(specificImplementation) {
+    /**
+     * @type {SpecificDetectorImplementation}
+     */
+    this.implementation = specificImplementation;
+
+    /**
+     * @type {Promise<boolean>}
+     * TODO: do we need to handle onReady callbacks?
+     */
+    this.ready = this.implementation.ready;
+
+    /**
+     * @type {InputImage | null}
+     * The video or image used for continuous detection.
+     */
+    this.detectMedia = null;
+    /**
+     * @type {function | null}
+     * Function to call with the results of each detection.
+     */
+    this.detectCallback = null;
+
+    // flags for detectStart() and detectStop()
+    /**
+     * @type {boolean}
+     * true when detection loop is running
+     */
+    this.detecting = false;
+    /**
+     * @type {boolean}
+     * Signal to stop the loop
+     */
+    this.signalStop = false;
+    /**
+     * @type {"start" | "stop" | ""}
+     * Track previous call to detectStart() or detectStop(),
+     * used for giving warning messages when detectStart() is called twice in a row.
+     */
+    this.prevCall = "";
+  }
+
+  /**
+   * Repeatedly output detections through a callback function
+   * @param {*} media - An HTML or p5.js image, video, or canvas element to run the detection on.
+   * @param {function} callback - A callback function to handle each detection.
+   * @void
+   */
+  detectStart(...inputs) {
+    // Parse out the input parameters
+    const argumentObject = handleArguments(...inputs);
+    argumentObject.require(
+      "image",
+      "An html or p5.js image, video, or canvas element argument is required for detectStart()."
+    );
+    argumentObject.require(
+      "callback",
+      "A callback function argument is required for detectStart()."
+    );
+    this.detectMedia = argumentObject.image;
+    this.detectCallback = argumentObject.callback;
+
+    this.signalStop = false;
+    if (!this.detecting) {
+      this.detecting = true;
+      this.detectLoop();
+    }
+    if (this.prevCall === "start") {
+      console.warn(
+        "detectStart() was called more than once without calling detectStop(). The latest detectStart() call will be used and the previous calls will be  ignored."
+      );
+    }
+    this.prevCall = "start";
+  }
+
+  /**
+   * Stop the detection loop before next detection runs.
+   */
+  detectStop() {
+    if (this.detecting) this.signalStop = true;
+    this.prevCall = "stop";
+  }
+
+  /**
+   * Internal function to call the detect method repeatedly in a loop
+   * Can be started by detectStart() and terminated by detectStop()
+   *
+   * @private
+   */
+  async detectLoop() {
+    // Make sure that both the model and the media are loaded before beginning.
+    await Promise.all([
+      this.ready,
+      mediaReady(this.detectMedia, false)
+    ]);
+
+    // Continuous detection loop.
+    while (!this.signalStop) {
+      const result = await this.implementation.detect(this.detectMedia);
+      this.detectCallback(result);
+      // wait for the frame to update
+      await tf.nextFrame();
+    }
+
+    // Update flags when done.
+    this.detecting = false;
+    this.signalStop = false;
+  }
+
+  /**
+   * Asynchronously output a single detection result when called
+   * @param {*} media - An HTML or p5.js image, video, or canvas element to run the detection on.
+   * @param {function} [callback] - A callback function to handle the detection results.
+   * @returns {Promise<Array>} an array of detections.
+   */
+  async detect(...inputs) {
+    // Parse out the input parameters
+    const argumentObject = handleArguments(...inputs);
+    argumentObject.require(
+      "image",
+      "An html or p5.js image, video, or canvas element argument is required for detect()."
+    );
+    const { image, callback } = argumentObject;
+
+    // Make sure that both the model and the media are loaded before beginning.
+    await Promise.all([
+      this.ready,
+      mediaReady(this.detectMedia, false)
+    ]);
+
+    const result = await this.implementation.detect(image);
+    if (typeof callback === "function") callback(result);
+    return result;
+  }
+
+}


### PR DESCRIPTION
The logic for `detectStart` and `detectStop` is the same for 4 of the models, so I moved those common parts into a new Helper class `ImageDetector`.  Then the ml5 functions `handPose` etc. return a new `ImageDetector` instance which internally uses an instance of the `HandPose` class.

Alternatively, we could define `ImageDetector` as a `abstract class` and use `class HandPose extends ImageDetector`.  That would be less flexible, but probably easier to understand?

I'm marking this as a draft because there's a few things that I may want to change, mainly moving the `this.ready` into the `ImageDetector`.  And also probably moving the p5 preload logic, but that's its own can of worms.