### PR TITLE
🧹 NeuralNetwork cleanup - passing arguments between methods

### DIFF
--- a/src/NeuralNetwork/NeuralNetwork.js
+++ b/src/NeuralNetwork/NeuralNetwork.js
@@ -57,11 +57,11 @@ class NeuralNetwork {
   /**
    * add layer to the model
    * if the model has 2 or more layers switch the isLayered flag
-   * @param {*} _layerOptions
+   * @param {tf.Layer} layer
+   * @void
    */
-  addLayer(_layerOptions) {
-    const LAYER_OPTIONS = _layerOptions || {};
-    this.model.add(LAYER_OPTIONS);
+  addLayer(layer) {
+    this.model.add(layer);
 
     // check if it has at least an input and output layer
     if (this.model.layers.length >= 2) {

--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -21,43 +21,6 @@ class NeuralNetworkData {
     this.data = {
       raw: [], // array of {xs:{}, ys:{}}
     };
-
-    // methods
-    // summarize data
-    this.createMetadata = this.createMetadata.bind(this);
-    this.getDataStats = this.getDataStats.bind(this);
-    this.getInputMetaStats = this.getInputMetaStats.bind(this);
-    this.getDataUnits = this.getDataUnits.bind(this);
-    this.getInputMetaUnits = this.getInputMetaUnits.bind(this);
-    this.getDTypesFromData = this.getDTypesFromData.bind(this);
-    // add data
-    this.addData = this.addData.bind(this);
-    // data conversion
-    this.convertRawToTensors = this.convertRawToTensors.bind(this);
-    // data normalization / unnormalization
-    this.normalizeDataRaw = this.normalizeDataRaw.bind(this);
-    this.normalizeInputData = this.normalizeInputData.bind(this);
-    this.normalizeArray = this.normalizeArray.bind(this);
-    this.unnormalizeArray = this.unnormalizeArray.bind(this);
-    // one hot
-    this.applyOneHotEncodingsToDataRaw =
-      this.applyOneHotEncodingsToDataRaw.bind(this);
-    this.getDataOneHot = this.getDataOneHot.bind(this);
-    this.getInputMetaOneHot = this.getInputMetaOneHot.bind(this);
-    this.createOneHotEncodings = this.createOneHotEncodings.bind(this);
-    // Saving / loading data
-    this.loadDataFromUrl = this.loadDataFromUrl.bind(this);
-    this.loadJSON = this.loadJSON.bind(this);
-    this.loadCSV = this.loadCSV.bind(this);
-    this.loadBlob = this.loadBlob.bind(this);
-    this.loadData = this.loadData.bind(this);
-    this.saveData = this.saveData.bind(this);
-    this.saveMeta = this.saveMeta.bind(this);
-    this.loadMeta = this.loadMeta.bind(this);
-    // data loading helpers
-    this.findEntries = this.findEntries.bind(this);
-    this.formatRawData = this.formatRawData.bind(this);
-    this.csvToJSON = this.csvToJSON.bind(this);
   }
 
   /**
@@ -73,21 +36,20 @@ class NeuralNetworkData {
    *  2. getting the min and max from the data
    *  3. getting the oneHot encoded values
    *  4. getting the inputShape and outputUnits from the data
-   * @param {*} dataRaw
-   * @param {*} inputShape
+   * @param {Array<number>} [inputShape]
+   * @void
    */
-  createMetadata(dataRaw, inputShape = null) {
+  createMetadata(inputShape = null) {
     // get the data type for each property
-    this.getDTypesFromData(dataRaw);
+    this.getDTypesFromData();
     // get the stats - min, max
-    this.getDataStats(dataRaw);
+    this.getDataStats();
     // onehot encode
-    this.getDataOneHot(dataRaw);
+    this.getDataOneHot();
     // calculate the input units from the data
-    this.getDataUnits(dataRaw, inputShape);
+    this.getDataUnits(inputShape);
 
     this.isMetadataReady = true;
-    return { ...this.meta };
   }
 
   /*
@@ -98,34 +60,22 @@ class NeuralNetworkData {
 
   /**
    * get stats about the data
-   * @param {*} dataRaw
+   * @private
+   * @void
    */
-  getDataStats(dataRaw) {
-    const meta = Object.assign({}, this.meta);
-
-    const inputMeta = this.getInputMetaStats(dataRaw, meta.inputs, "xs");
-    const outputMeta = this.getInputMetaStats(dataRaw, meta.outputs, "ys");
-
-    meta.inputs = inputMeta;
-    meta.outputs = outputMeta;
-
-    this.meta = {
-      ...this.meta,
-      ...meta,
-    };
-
-    return meta;
+  getDataStats() {
+    this.meta.inputs = this.getInputMetaStats(this.meta.inputs, "xs");
+    this.meta.outputs = this.getInputMetaStats(this.meta.outputs, "ys");
   }
 
   /**
-   * getRawStats
    * get back the min and max of each label
-   * @param {*} dataRaw
-   * @param {*} inputOrOutputMeta
-   * @param {*} xsOrYs
+   * @private
+   * @param {Object} inputOrOutputMeta
+   * @param {"xs" | "ys"} xsOrYs
+   * @return {Object}
    */
-  // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  getInputMetaStats(dataRaw, inputOrOutputMeta, xsOrYs) {
+  getInputMetaStats(inputOrOutputMeta, xsOrYs) {
     const inputMeta = Object.assign({}, inputOrOutputMeta);
 
     Object.keys(inputMeta).forEach((k) => {
@@ -133,11 +83,11 @@ class NeuralNetworkData {
         inputMeta[k].min = 0;
         inputMeta[k].max = 1;
       } else if (inputMeta[k].dtype === "number") {
-        const dataAsArray = dataRaw.map((item) => item[xsOrYs][k]);
+        const dataAsArray = this.data.raw.map((item) => item[xsOrYs][k]);
         inputMeta[k].min = nnUtils.getMin(dataAsArray);
         inputMeta[k].max = nnUtils.getMax(dataAsArray);
       } else if (inputMeta[k].dtype === "array") {
-        const dataAsArray = dataRaw.map((item) => item[xsOrYs][k]).flat();
+        const dataAsArray = this.data.raw.map((item) => item[xsOrYs][k]).flat();
         inputMeta[k].min = nnUtils.getMin(dataAsArray);
         inputMeta[k].max = nnUtils.getMax(dataAsArray);
       }
@@ -148,42 +98,29 @@ class NeuralNetworkData {
 
   /**
    * get the data units, inputshape and output units
-   * @param {*} dataRaw
+   * @private
+   * @param {Array<number>} arrayShape
+   * @void
    */
-  getDataUnits(dataRaw, _arrayShape = null) {
-    const arrayShape = _arrayShape !== null ? _arrayShape : undefined;
-    const meta = Object.assign({}, this.meta);
-
+  getDataUnits(arrayShape = null) {
     // if the data has a shape pass it in
-    let inputShape;
     if (arrayShape) {
-      inputShape = arrayShape;
+      this.meta.inputUnits = arrayShape;
     } else {
-      inputShape = [this.getInputMetaUnits(dataRaw, meta.inputs)].flat();
+      this.meta.inputUnits = [this.getInputMetaUnits(this.meta.inputs)].flat();
     }
 
-    const outputShape = this.getInputMetaUnits(dataRaw, meta.outputs);
-
-    meta.inputUnits = inputShape;
-    meta.outputUnits = outputShape;
-
-    this.meta = {
-      ...this.meta,
-      ...meta,
-    };
-
-    return meta;
+    this.meta.outputUnits = this.getInputMetaUnits(this.meta.outputs);
   }
 
   /**
-   * get input
-   * @param {*} _inputsMeta
-   * @param {*} _dataRaw
+   * @private
+   * @param {Object} inputsMeta
+   * @return {number | Array<number>}
    */
-  // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  getInputMetaUnits(_dataRaw, _inputsMeta) {
+  // eslint-disable-next-line class-methods-use-this
+  getInputMetaUnits(inputsMeta) {
     let units = 0;
-    const inputsMeta = Object.assign({}, _inputsMeta);
 
     Object.entries(inputsMeta).forEach((arr) => {
       const { dtype } = arr[1];
@@ -208,15 +145,17 @@ class NeuralNetworkData {
    * getDTypesFromData
    * gets the data types of the data we're using
    * important for handling oneHot
+   * @private
+   * @void - updates this.meta
    */
-  getDTypesFromData(_dataRaw) {
+  getDTypesFromData() {
     const meta = {
       ...this.meta,
       inputs: {},
       outputs: {},
     };
 
-    const sample = _dataRaw[0];
+    const sample = this.data.raw[0];
     const xs = Object.keys(sample.xs);
     const ys = Object.keys(sample.ys);
 
@@ -236,8 +175,6 @@ class NeuralNetworkData {
     // otherwise throw an error
 
     this.meta = meta;
-
-    return meta;
   }
 
   /**
@@ -250,6 +187,7 @@ class NeuralNetworkData {
    * Add Data
    * @param {object} xInputObj, {key: value}, key must be the name of the property value must be a String, Number, or Array
    * @param {*} yInputObj, {key: value}, key must be the name of the property value must be a String, Number, or Array
+   * @void - updates this.data
    */
   addData(xInputObj, yInputObj) {
     this.data.raw.push({
@@ -267,8 +205,9 @@ class NeuralNetworkData {
   /**
    * convertRawToTensors
    * converts array of {xs, ys} to tensors
-   * @param {*} _dataRaw
-   * @param {*} meta
+   * @param {*} dataRaw
+   *
+   * @return {{ inputs: tf.Tensor, outputs: tf.Tensor }}
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   convertRawToTensors(dataRaw) {
@@ -323,13 +262,11 @@ class NeuralNetworkData {
 
   /**
    * normalize the dataRaw input
-   * @param {*} dataRaw
+   * @return {Array<object>}
    */
-  normalizeDataRaw(dataRaw) {
-    const meta = Object.assign({}, this.meta);
-
-    const normXs = this.normalizeInputData(dataRaw, meta.inputs, "xs");
-    const normYs = this.normalizeInputData(dataRaw, meta.outputs, "ys");
+  normalizeDataRaw() {
+    const normXs = this.normalizeInputData(this.meta.inputs, "xs");
+    const normYs = this.normalizeInputData(this.meta.outputs, "ys");
 
     const normalizedData = nnUtils.zipArrays(normXs, normYs);
 
@@ -337,13 +274,12 @@ class NeuralNetworkData {
   }
 
   /**
-   * normalizeRaws
-   * @param {*} dataRaw
-   * @param {*} inputOrOutputMeta
-   * @param {*} xsOrYs
+   * @param {Object} inputOrOutputMeta
+   * @param {"xs" | "ys"} xsOrYs
+   * @return {Array<object>}
    */
-  // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  normalizeInputData(dataRaw, inputOrOutputMeta, xsOrYs) {
+  normalizeInputData(inputOrOutputMeta, xsOrYs) {
+    const dataRaw = this.data.raw;
     // the data length
     const dataLength = dataRaw.length;
     // the copy of the inputs.meta[inputOrOutput]
@@ -471,13 +407,11 @@ class NeuralNetworkData {
    * applyOneHotEncodingsToDataRaw
    * does not set this.data.raws
    * but rather returns them
-   * @param {*} _dataRaw
-   * @param {*} _meta
    */
-  applyOneHotEncodingsToDataRaw(dataRaw) {
+  applyOneHotEncodingsToDataRaw() {
     const meta = Object.assign({}, this.meta);
 
-    const output = dataRaw.map((row) => {
+    const output = this.data.raw.map((row) => {
       const xs = {
         ...row.xs,
       };
@@ -510,32 +444,21 @@ class NeuralNetworkData {
    * getDataOneHot
    * creates onehot encodings for the input and outputs
    * and adds them to the meta info
-   * @param {*} dataRaw
+   * @private
+   * @void
    */
-  getDataOneHot(dataRaw) {
-    const meta = Object.assign({}, this.meta);
-
-    const inputMeta = this.getInputMetaOneHot(dataRaw, meta.inputs, "xs");
-    const outputMeta = this.getInputMetaOneHot(dataRaw, meta.outputs, "ys");
-
-    meta.inputs = inputMeta;
-    meta.outputs = outputMeta;
-
-    this.meta = {
-      ...this.meta,
-      ...meta,
-    };
-
-    return meta;
+  getDataOneHot() {
+    this.meta.inputs = this.getInputMetaOneHot(this.meta.inputs, "xs");
+    this.meta.outputs = this.getInputMetaOneHot(this.meta.outputs, "ys");
   }
 
   /**
    * getOneHotMeta
-   * @param {*} _inputsMeta
-   * @param {*} _dataRaw
-   * @param {*} xsOrYs
+   * @param {Object} _inputsMeta
+   * @param {"xs" | "ys"} xsOrYs
+   * @return {Object}
    */
-  getInputMetaOneHot(_dataRaw, _inputsMeta, xsOrYs) {
+  getInputMetaOneHot(_inputsMeta, xsOrYs) {
     const inputsMeta = Object.assign({}, _inputsMeta);
 
     Object.entries(inputsMeta).forEach((arr) => {
@@ -546,7 +469,7 @@ class NeuralNetworkData {
 
       if (dtype === "string") {
         const uniqueVals = [
-          ...new Set(_dataRaw.map((obj) => obj[xsOrYs][key])),
+          ...new Set(this.data.raw.map((obj) => obj[xsOrYs][key])),
         ];
         const oneHotMeta = this.createOneHotEncodings(uniqueVals);
         inputsMeta[key] = {
@@ -562,6 +485,9 @@ class NeuralNetworkData {
   /**
    * Returns a legend mapping the
    * data values to oneHot encoded values
+   * @private
+   * @param {Array<string>} _uniqueValuesArray
+   * @return {Object}
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   createOneHotEncodings(_uniqueValuesArray) {
@@ -602,22 +528,20 @@ class NeuralNetworkData {
    * @param {*} dataUrl
    * @param {*} inputs
    * @param {*} outputs
+   * @void
    */
   async loadDataFromUrl(dataUrl, inputs, outputs) {
     try {
-      let result;
 
       if (dataUrl.endsWith(".csv")) {
-        result = await this.loadCSV(dataUrl, inputs, outputs);
+        await this.loadCSV(dataUrl, inputs, outputs);
       } else if (dataUrl.endsWith(".json")) {
-        result = await this.loadJSON(dataUrl, inputs, outputs);
+        await this.loadJSON(dataUrl, inputs, outputs);
       } else if (dataUrl.includes("blob")) {
-        result = await this.loadBlob(dataUrl, inputs, outputs);
+        await this.loadBlob(dataUrl, inputs, outputs);
       } else {
         throw new Error("Not a valid data format. Must be csv or json");
       }
-
-      return result;
     } catch (error) {
       console.error(error);
       throw new Error(error);
@@ -626,9 +550,10 @@ class NeuralNetworkData {
 
   /**
    * loadJSON
-   * @param {*} _dataUrlOrJson
-   * @param {*} _inputLabelsArray
-   * @param {*} _outputLabelsArray
+   * @param {*} dataUrlOrJson
+   * @param {*} inputLabels
+   * @param {*} outputLabels
+   * @void
    */
   async loadJSON(dataUrlOrJson, inputLabels, outputLabels) {
     try {
@@ -642,8 +567,7 @@ class NeuralNetworkData {
       }
 
       // format the data.raw array
-      const result = this.formatRawData(json, inputLabels, outputLabels);
-      return result;
+      this.formatRawData(json, inputLabels, outputLabels);
     } catch (err) {
       console.error("error loading json");
       throw new Error(err);
@@ -652,9 +576,10 @@ class NeuralNetworkData {
 
   /**
    * loadCSV
-   * @param {*} _dataUrl
-   * @param {*} _inputLabelsArray
-   * @param {*} _outputLabelsArray
+   * @param {*} dataUrl
+   * @param {*} inputLabels
+   * @param {*} outputLabels
+   * @void
    */
   async loadCSV(dataUrl, inputLabels, outputLabels) {
     try {
@@ -664,8 +589,7 @@ class NeuralNetworkData {
         entries: loadedData,
       };
       // format the data.raw array
-      const result = this.formatRawData(json, inputLabels, outputLabels);
-      return result;
+      this.formatRawData(json, inputLabels, outputLabels);
     } catch (err) {
       console.error("error loading csv", err);
       throw new Error(err);
@@ -674,25 +598,23 @@ class NeuralNetworkData {
 
   /**
    * loadBlob
-   * @param {*} _dataUrlOrJson
-   * @param {*} _inputLabelsArray
-   * @param {*} _outputLabelsArray
+   * @param {*} dataUrlOrJson
+   * @param {*} inputLabels
+   * @param {*} outputLabels
+   * @void
    */
   async loadBlob(dataUrlOrJson, inputLabels, outputLabels) {
     try {
       const { data } = await axios.get(dataUrlOrJson);
       const text = data; // await data.text();
 
-      let result;
       if (nnUtils.isJsonOrString(text)) {
         const json = JSON.parse(text);
-        result = await this.loadJSON(json, inputLabels, outputLabels);
+        await this.loadJSON(json, inputLabels, outputLabels);
       } else {
         const json = this.csvToJSON(text);
-        result = await this.loadJSON(json, inputLabels, outputLabels);
+        await this.loadJSON(json, inputLabels, outputLabels);
       }
-
-      return result;
     } catch (err) {
       console.log("mmm might be passing in a string or something!", err);
       throw new Error(err);
@@ -873,8 +795,9 @@ class NeuralNetworkData {
    * formatRawData
    * takes a json and set the this.data.raw
    * @param {*} json 
-   * @param {Array} inputLabels
-   * @param {Array} outputLabels
+   * @param {Array<string>} inputLabels
+   * @param {Array<string>} outputLabels
+   * @void
    */
   formatRawData(json, inputLabels, outputLabels) {
     // Recurse through the json object to find
@@ -914,8 +837,6 @@ class NeuralNetworkData {
 
     // set this.data.raw
     this.data.raw = result;
-
-    return result;
   }
 
   /**

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -1,15 +1,12 @@
 import * as tf from "@tensorflow/tfjs";
+import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
+import { imgToPixelArray, isInstanceOfSupportedElement, } from "../utils/imageUtilities";
 import NeuralNetwork from "./NeuralNetwork";
 import NeuralNetworkData from "./NeuralNetworkData";
-import NeuralNetworkVis from "./NeuralNetworkVis";
-import callCallback from "../utils/callcallback";
 
 import nnUtils from "./NeuralNetworkUtils";
-import {
-  imgToPixelArray,
-  isInstanceOfSupportedElement,
-} from "../utils/imageUtilities";
+import NeuralNetworkVis from "./NeuralNetworkVis";
 
 const DEFAULTS = {
   inputs: [],
@@ -130,6 +127,8 @@ class DiyNeuralNetwork {
 
   /**
    * createLayersNoTraining
+   * @private
+   * @void
    */
   createLayersNoTraining() {
     // Create sample data based on options
@@ -145,8 +144,9 @@ class DiyNeuralNetwork {
       this.addData(inputSample, outputSample);
     }
 
-    this.neuralNetworkData.createMetadata(this.neuralNetworkData.data.raw);
-    this.addDefaultLayers(this.options.task, this.neuralNetworkData.meta);
+    // TODO: what about inputShape?
+    this.neuralNetworkData.createMetadata();
+    this.addDefaultLayers();
   }
 
   /**
@@ -239,7 +239,7 @@ class DiyNeuralNetwork {
   async loadDataInternal(options) {
     const { dataUrl, inputs, outputs } = options;
 
-    const data = await this.neuralNetworkData.loadDataFromUrl(
+    await this.neuralNetworkData.loadDataFromUrl(
       dataUrl,
       inputs,
       outputs
@@ -248,9 +248,9 @@ class DiyNeuralNetwork {
     // once the data are loaded, create the metadata
     // and prep the data for training
     // if the inputs are defined as an array of [img_width, img_height, channels]
-    this.createMetadata(data);
+    this.createMetaData();
 
-    this.prepareForTraining(data);
+    this.prepareForTraining();
   }
 
   /**
@@ -259,7 +259,7 @@ class DiyNeuralNetwork {
    * ////////////////////////////////////////////////////////////
    */
 
-  createMetaData(dataRaw) {
+  createMetaData() {
     const { inputs } = this.options;
 
     let inputShape;
@@ -270,7 +270,7 @@ class DiyNeuralNetwork {
           : null;
     }
 
-    this.neuralNetworkData.createMetadata(dataRaw, inputShape);
+    this.neuralNetworkData.createMetadata(inputShape);
   }
 
   /**
@@ -281,46 +281,36 @@ class DiyNeuralNetwork {
 
   /**
    * Prepare data for training by applying oneHot to raw
-   * @param {*} dataRaw
+   * @private
+   * @void
    */
-  prepareForTraining(_dataRaw = null) {
-    const dataRaw =
-      _dataRaw === null ? this.neuralNetworkData.data.raw : _dataRaw;
-    const unnormalizedTrainingData =
-      this.neuralNetworkData.applyOneHotEncodingsToDataRaw(dataRaw);
-    this.data.training = unnormalizedTrainingData;
+  prepareForTraining() {
+    this.data.training = this.neuralNetworkData.applyOneHotEncodingsToDataRaw();
     this.neuralNetworkData.isWarmedUp = true;
-
-    return unnormalizedTrainingData;
   }
 
   /**
    * normalizeData
-   * @param {*} _dataRaw
-   * @param {*} _meta
+   * @public
+   * @void
    */
-  normalizeData(_dataRaw = null) {
-    const dataRaw =
-      _dataRaw === null ? this.neuralNetworkData.data.raw : _dataRaw;
-
+  normalizeData() {
     if (!this.neuralNetworkData.isMetadataReady) {
       // if the inputs are defined as an array of [img_width, img_height, channels]
-      this.createMetaData(dataRaw);
+      this.createMetaData();
     }
 
     if (!this.neuralNetworkData.isWarmedUp) {
-      this.prepareForTraining(dataRaw);
+      this.prepareForTraining();
     }
 
-    const trainingData = this.neuralNetworkData.normalizeDataRaw(dataRaw);
+    const trainingData = this.neuralNetworkData.normalizeDataRaw();
 
     // set this equal to the training data
     this.data.training = trainingData;
 
     // set isNormalized to true
     this.neuralNetworkData.meta.isNormalized = true;
-
-    return trainingData;
   }
 
   /**
@@ -328,6 +318,7 @@ class DiyNeuralNetwork {
    * @param {*} value
    * @param {*} _key
    * @param {*} _meta
+   * @return {number}
    */
   // eslint-disable-next-line class-methods-use-this
   normalizeInput(value, _key, _meta) {
@@ -339,6 +330,7 @@ class DiyNeuralNetwork {
   /**
    * search though the xInputs and format for adding to data.raws
    * @param {*} input
+   * @return
    */
   searchAndFormat(input) {
     let formattedInputs;
@@ -358,6 +350,7 @@ class DiyNeuralNetwork {
   /**
    * Returns either the original input or a pixelArray[]
    * @param {*} input
+   * @return
    */
   // eslint-disable-next-line class-methods-use-this
   formatInputItem(input) {
@@ -388,15 +381,11 @@ class DiyNeuralNetwork {
 
   /**
    * convertTrainingDataToTensors
-   * @param {*} _trainingData
-   * @param {*} _meta
+   * @private
+   * @return {{ inputs: tf.Tensor, outputs: tf.Tensor }}
    */
-  convertTrainingDataToTensors(_trainingData = null, _meta = null) {
-    const trainingData =
-      _trainingData === null ? this.data.training : _trainingData;
-    const meta = _meta === null ? this.neuralNetworkData.meta : _meta;
-
-    return this.neuralNetworkData.convertRawToTensors(trainingData, meta);
+  convertTrainingDataToTensors() {
+    return this.neuralNetworkData.convertRawToTensors(this.data.training);
   }
 
   /**
@@ -404,11 +393,14 @@ class DiyNeuralNetwork {
    * this means applying onehot or normalization
    * so that the user can use original data units rather
    * than having to normalize
+   * @private
    * @param {*} _input
-   * @param {*} meta
-   * @param {*} inputHeaders
+   * @return {Array<number>}
    */
-  formatInputsForPrediction(_input, meta, inputHeaders) {
+  formatInputsForPrediction(_input) {
+    const { meta } = this.neuralNetworkData;
+    const inputHeaders = Object.keys(meta.inputs);
+
     let inputData = [];
 
     // TODO: check to see if it is a nested array
@@ -437,26 +429,29 @@ class DiyNeuralNetwork {
 
   /**
    * formatInputsForPredictionAll
+   * @private
    * @param {*} _input
-   * @param {*} meta
-   * @param {*} inputHeaders
+   * @return {tf.Tensor}
    */
-  formatInputsForPredictionAll(_input, meta, inputHeaders) {
+  formatInputsForPredictionAll(_input) {
+    const { meta } = this.neuralNetworkData;
+    const inputHeaders = Object.keys(meta.inputs);
+
     let output;
 
     if (_input instanceof Array) {
       if (_input.every((item) => Array.isArray(item))) {
         output = _input.map((item) => {
-          return this.formatInputsForPrediction(item, meta, inputHeaders);
+          return this.formatInputsForPrediction(item);
         });
 
         return tf.tensor(output, [_input.length, inputHeaders.length]);
       }
-      output = this.formatInputsForPrediction(_input, meta, inputHeaders);
+      output = this.formatInputsForPrediction(_input);
       return tf.tensor([output]);
     }
 
-    output = this.formatInputsForPrediction(_input, meta, inputHeaders);
+    output = this.formatInputsForPrediction(_input);
     return tf.tensor([output]);
   }
 
@@ -491,6 +486,7 @@ class DiyNeuralNetwork {
 
   /**
    * train
+   * @public
    * @param {*} optionsOrCallback
    * @param {*} optionsOrWhileTraining
    * @param {*} callback
@@ -572,12 +568,12 @@ class DiyNeuralNetwork {
     // if metadata needs to be generated about the data
     if (!this.neuralNetworkData.isMetadataReady) {
       // if the inputs are defined as an array of [img_width, img_height, channels]
-      this.createMetaData(this.neuralNetworkData.data.raw);
+      this.createMetaData();
     }
 
     // if the data still need to be summarized, onehotencoded, etc
     if (!this.neuralNetworkData.isWarmedUp) {
-      this.prepareForTraining(this.neuralNetworkData.data.raw);
+      this.prepareForTraining();
     }
 
     // if inputs and outputs are not specified
@@ -592,19 +588,17 @@ class DiyNeuralNetwork {
     // check to see if layers are passed into the constructor
     // then use those to create your architecture
     if (!this.neuralNetwork.isLayered) {
+      // TODO: don't update this.options.layers - Linda
       this.options.layers = this.createNetworkLayers(
-        this.options.layers,
-        this.neuralNetworkData.meta
+        this.options.layers
       );
     }
 
     // if the model does not have any layers defined yet
     // then use the default structure
     if (!this.neuralNetwork.isLayered) {
-      this.options.layers = this.addDefaultLayers(
-        this.options.task,
-        this.neuralNetworkData.meta
-      );
+      // TODO: don't update this.options.layers - Linda
+      this.options.layers = this.addDefaultLayers();
     }
 
     if (!this.neuralNetwork.isCompiled) {
@@ -618,19 +612,22 @@ class DiyNeuralNetwork {
 
   /**
    * addLayer
-   * @param {*} options
+   * @param {tf.Layer} layer
    */
-  addLayer(options) {
-    this.neuralNetwork.addLayer(options);
+  addLayer(layer) {
+    this.neuralNetwork.addLayer(layer);
   }
 
   /**
    * add custom layers in options
+   * @private
+   * @param {Array} layerJsonArray
+   * @returns // TODO: make void
    */
-  createNetworkLayers(layerJsonArray, meta) {
+  createNetworkLayers(layerJsonArray) {
     const layers = [...layerJsonArray];
 
-    const { inputUnits, outputUnits } = Object.assign({}, meta);
+    const { inputUnits, outputUnits } = this.neuralNetworkData.meta;
     const layersLength = layers.length;
 
     if (!(layers.length >= 2)) {
@@ -687,10 +684,12 @@ class DiyNeuralNetwork {
 
   /**
    * addDefaultLayers
-   * @param {*} _task
+   * @private
+   * @returns // TODO: make void
    */
-  addDefaultLayers(task, meta) {
+  addDefaultLayers() {
     let layers;
+    const task = this.options.task;
     switch (task.toLowerCase()) {
       // if the task is classification
       case "classification":
@@ -706,7 +705,7 @@ class DiyNeuralNetwork {
           },
         ];
 
-        return this.createNetworkLayers(layers, meta);
+        return this.createNetworkLayers(layers);
       // if the task is regression
       case "regression":
         layers = [
@@ -720,7 +719,7 @@ class DiyNeuralNetwork {
             activation: "sigmoid",
           },
         ];
-        return this.createNetworkLayers(layers, meta);
+        return this.createNetworkLayers(layers);
       // if the task is imageClassification
       case "imageclassification":
         layers = [
@@ -759,7 +758,7 @@ class DiyNeuralNetwork {
             activation: "softmax",
           },
         ];
-        return this.createNetworkLayers(layers, meta);
+        return this.createNetworkLayers(layers);
 
       default:
         console.log("no imputUnits or outputUnits defined");
@@ -774,25 +773,21 @@ class DiyNeuralNetwork {
             activation: "sigmoid",
           },
         ];
-        return this.createNetworkLayers(layers, meta);
+        return this.createNetworkLayers(layers);
     }
   }
 
   /**
    * compile the model
-   * @param {*} _options
+   * @private
+   * @void
    */
-  compile(_modelOptions = null, _learningRate = null) {
-    const LEARNING_RATE =
-      _learningRate === null ? this.options.learningRate : _learningRate;
+  compile() {
+    const LEARNING_RATE = this.options.learningRate;
 
     let options = {};
 
-    if (_modelOptions !== null) {
-      options = {
-        ..._modelOptions,
-      };
-    } else if (
+    if (
       this.options.task === "classification" ||
       this.options.task === "imageClassification"
     ) {
@@ -894,9 +889,8 @@ class DiyNeuralNetwork {
    */
   predictSyncInternal(_input) {
     const { meta } = this.neuralNetworkData;
-    const headers = Object.keys(meta.inputs);
 
-    const inputData = this.formatInputsForPredictionAll(_input, meta, headers);
+    const inputData = this.formatInputsForPredictionAll(_input);
 
     const unformattedResults = this.neuralNetwork.predictSync(inputData);
     inputData.dispose();
@@ -954,9 +948,8 @@ class DiyNeuralNetwork {
    */
   async predictInternal(_input) {
     const { meta } = this.neuralNetworkData;
-    const headers = Object.keys(meta.inputs);
 
-    const inputData = this.formatInputsForPredictionAll(_input, meta, headers);
+    const inputData = this.formatInputsForPredictionAll(_input);
 
     const unformattedResults = await this.neuralNetwork.predict(inputData);
     inputData.dispose();
@@ -1042,7 +1035,7 @@ class DiyNeuralNetwork {
 
       inputData = tf.tensor([inputData], [1, ...meta.inputUnits]);
     } else {
-      inputData = this.formatInputsForPredictionAll(_input, meta, headers);
+      inputData = this.formatInputsForPredictionAll(_input);
     }
 
     const unformattedResults = this.neuralNetwork.classifySync(inputData);
@@ -1110,7 +1103,7 @@ class DiyNeuralNetwork {
 
       inputData = tf.tensor([inputData], [1, ...meta.inputUnits]);
     } else {
-      inputData = this.formatInputsForPredictionAll(_input, meta, headers);
+      inputData = this.formatInputsForPredictionAll(_input);
     }
 
     const unformattedResults = await this.neuralNetwork.classify(inputData);


### PR DESCRIPTION
A. There are a lot of method calls in the NeuralNetwork classes which pass around variables that are properties of `this`.  If the argument is the same every time that the method is called then it doesn't need to be an argument -- instead the method can access the property itself.

Removed `dataRaw` argument from:
- prepareForTraining
- normalizeData
- normalizeDataRaw
- normalizeInputData
- getDataOneHot
- getInputMetaOneHot
- applyOneHotEncodingsToDataRaw
- convertTrainingDataToTensors
- createMetadata & createMetaData
- getDTypesFromData
- getDataStats
- getInputMetaStats
- getDataUnits
- getInputMetaUnits

Removed other arguments from:
- formatInputsForPredictionAll (`meta` and `inputHeaders`)
- formatInputsForPrediction (`meta` and `inputHeaders`)
- createNetworkLayers (`meta`)
- addDefaultLayers (`task` and `meta`)
- compile (`_modelOptions` and `_learningRate`)

---

B. Removed `return` statements that were not actually needed from a bunch of methods.  These values were either not used already, or were only used for arguments which I removed. Generally speaking, a method should either modify `this` or return a value but not both.

Removed the return value from:
- loadCSV
- loadJSON
- loadBlob
- loadDataFromUrl
- formatRawData
- prepareForTraining
- normalizeData
- createMetadata
- getDTypesFromData
- getDataStats
- getDataOneHot
- getDataUnits

---

C. Removed the whole block of `.bind(this);` from the `NeuralNetworkData` constructor.  The only benefit of this sort of binding is that it allows you to pass the method around as a variable without losing the `this` context.  For example, you can write `input.map(this.formatInputItem)` instead of `input.map((item) => this.formatInputItem(item))`.  But we don't do that anywhere in the code.  We can leave the `.bind` in on the public methods of the `DiyNeuralNetwork` class to support that sort of usage by end-users.  For all private and internal methods it's useless.

---

D. Removed some unnecessary cloning/copying of variables, such as `const meta = Object.assign({}, this.meta);`.  This creates a shallow copy.  So when we then use `meta.inputs` it is a reference to the same object as `this.meta.inputs`.  That's not a problem but it means that the cloning doesn't accomplish anything and should be removed.