### PR TITLE
Create tests for modelLoader.js + fix relative path handling

### DIFF
--- a/src/utils/modelLoader.js
+++ b/src/utils/modelLoader.js
@@ -18,9 +18,16 @@ export function isAbsoluteURL(str) {
  * @param {string} absoluteOrRelativeUrl
  * @returns {string}
  */
-export function getModelPath(absoluteOrRelativeUrl) {
+export function getAbsolutePath(absoluteOrRelativeUrl) {
   if (!isAbsoluteURL(absoluteOrRelativeUrl) && typeof window !== "undefined") {
-    return window.location.pathname + absoluteOrRelativeUrl;
+    // If it starts with "/" then it is relative to the domain/subdomain.
+    if (absoluteOrRelativeUrl.startsWith('/')) {
+      return window.location.origin + absoluteOrRelativeUrl;
+    }
+    // Otherwise it is relative to the current page.
+    let base = window.location.href;
+    if (!base.endsWith('/')) base += '/';
+    return base + absoluteOrRelativeUrl;
   }
   return absoluteOrRelativeUrl;
 }
@@ -45,7 +52,7 @@ class ModelLoader {
    * @param {boolean} prepend
    */
   constructor(path, expected = "model", prepend = true) {
-    const url = prepend ? getModelPath(path) : path;
+    const url = prepend ? getAbsolutePath(path) : path;
     const known = {};
     // If a specific URL is provided, make sure that we don't overwrite it with generic '/model.json'
     // But warn the user and try to correct if it seems like they passed the wrong file type.

--- a/src/utils/modelLoader.test.js
+++ b/src/utils/modelLoader.test.js
@@ -1,0 +1,70 @@
+import modelLoader, { isAbsoluteURL } from './modelLoader';
+
+describe('isAbsoluteURL', () => {
+  it('returns false if relative', () => {
+    expect(isAbsoluteURL('/model.json')).toBe(false);
+    expect(isAbsoluteURL('/deep/folder')).toBe(false);
+    expect(isAbsoluteURL('folder/model.json')).toBe(false);
+  });
+
+  it('returns true if absolute', () => {
+    expect(isAbsoluteURL('https://example.com/model.json')).toBe(true);
+    expect(isAbsoluteURL('http://example.com/model.json')).toBe(true);
+    expect(isAbsoluteURL('https://example.com/deep/folder')).toBe(true);
+  });
+});
+
+describe('modelLoader', () => {
+  const warnSpy = jest.spyOn(console, 'warn');
+
+  it('formulates URLs relative to the provided path', () => {
+    const loader = modelLoader('https://example.com/model.json');
+    expect(loader.modelUrl).toBe('https://example.com/model.json');
+    expect(loader.manifestUrl).toBe('https://example.com/manifest.json');
+    expect(loader.metadataUrl).toBe('https://example.com/metadata.json');
+  });
+
+  it('can start with just a directory', () => {
+    const loader = modelLoader('https://example.com/folder');
+    expect(loader.modelUrl).toBe('https://example.com/folder/model.json');
+    expect(loader.manifestUrl).toBe('https://example.com/folder/manifest.json');
+    expect(loader.metadataUrl).toBe('https://example.com/folder/metadata.json');
+  });
+
+  it('will absolutize relative paths by default', () => {
+    // Fake the current location
+    Object.defineProperty(window, 'location', {
+      get() {
+        return {
+          href: 'https://fakedomain.com/page',
+          origin: 'https://fakedomain.com'
+        };
+      },
+    });
+    // relative to page
+    const loader = modelLoader('folder/model.json');
+    expect(loader.modelUrl).toBe('https://fakedomain.com/page/folder/model.json');
+    // relative to root
+    const loader2 = modelLoader('/folder/model.json');
+    expect(loader2.modelUrl).toBe('https://fakedomain.com/folder/model.json');
+  });
+
+  it('will not absolutize paths if using "prepend" false' , () => {
+    const loader = modelLoader('folder/model.json', 'model', false);
+    expect(loader.modelUrl).toBe('folder/model.json');
+  });
+
+  it('will respect an arbitrary file name (not "model.json")', () => {
+    const loader = modelLoader('https://example.com/custom_model_file.json', 'model');
+    expect(loader.modelUrl).toBe('https://example.com/custom_model_file.json');
+    expect(loader.manifestUrl).toBe('https://example.com/manifest.json');
+    expect(loader.metadataUrl).toBe('https://example.com/metadata.json');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('will warn on recognized wrong file type', () => {
+    const loader = modelLoader('https://example.com/manifest.json', 'model');
+    expect(warnSpy).toHaveBeenCalled();
+    expect(loader.modelUrl).toBe('https://example.com/model.json');
+  });
+});


### PR DESCRIPTION
This PR adds tests for the URL-handling utilities in the `modelLoader.js` file.

I also fixed some issues that I found due to failures in tests.  When I wrote the `ModelLoader` class [I didn't modify the `getModelPath` function](https://github.com/ml5js/ml5-library/commit/674c4759c86580ad159006f0dca10398d70e64a4#diff-9ab9ff082c354557f42d0cbc28bae4afacb65dff78e1b150e24206d8a0deb101) (which I have now renamed to `getAbsolutePath` because that is a more descriptive name of what it does).  This function wasn't really doing the right thing because it was using `window.location.pathname` which does not include the domain.  It also wasn't looking for trailing or leading slashes, so it could wind up with no `/` or with a double `//`.  The revised version can now properly handle paths which are relative to the root (`'/folder/model.json'`) or relative to the current page (`'folder/model.json'`).  It can NOT handle more complex relative paths, like `'../folder/model.json'`.

#### Follow-up
Right now we are by default converting all relative URLs to absolute URLs.  We should see if this is actually necessary and/or beneficial.  If we do nothing, can TFJS load a file from `'../folder/model.json'`?