### PR TITLE
fix mouse gesture example click without drag bug

### DIFF
--- a/examples/NeuralNetwork-mouse-gesture/sketch.js
+++ b/examples/NeuralNetwork-mouse-gesture/sketch.js
@@ -69,6 +69,7 @@ function draw() {
 
 function mousePressed() {
   start = createVector(mouseX, mouseY);
+  end = createVector(mouseX, mouseY);
 }
 
 function mouseDragged() {


### PR DESCRIPTION
This PR fixes the bug of #90 by recoding the end position in addition to the start position when `mousePressed` is called. 