### PR TITLE
Resize body pose bounding box

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -248,6 +248,7 @@ class BodyPose {
     );
     let result = predictions;
     result = this.addKeypoints(result);
+    this.resizeBoundingBoxes(result, image.width, image.height);
     if (typeof callback === "function") callback(result);
     return result;
   }
@@ -300,6 +301,11 @@ class BodyPose {
       );
       let result = predictions;
       result = this.addKeypoints(result);
+      this.resizeBoundingBoxes(
+        result,
+        this.detectMedia.width,
+        this.detectMedia.height
+      );
       this.detectCallback(result);
       // wait for the frame to update
       await tf.nextFrame();
@@ -335,6 +341,28 @@ class BodyPose {
       return hand;
     });
     return result;
+  }
+
+  /**
+   * Resize the bounding box values from between 0-1 to the original media size.
+   *
+   * @param {Array} poses - the original detection results.
+   * @param {*} imageWidth - the width of the media being detected.
+   * @param {*} imageHeight - the height of the media being detected.
+   * @private
+   */
+  resizeBoundingBoxes(poses, imageWidth, imageHeight) {
+    // Only MoveNet model has box property
+    if (poses[0] && poses[0].box) {
+      poses.forEach((pose) => {
+        pose.box.height = pose.box.height * imageHeight;
+        pose.box.width = pose.box.width * imageWidth;
+        pose.box.xMax = pose.box.xMax * imageWidth;
+        pose.box.xMin = pose.box.xMin * imageWidth;
+        pose.box.yMax = pose.box.yMax * imageHeight;
+        pose.box.yMin = pose.box.yMin * imageHeight;
+      });
+    }
   }
 
   /**

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -324,21 +324,21 @@ class BodyPose {
 
   /**
    * Return a new array of results with named keypoints added.
-   * @param {Array} hands - the original detection results.
+   * @param {Array} poses - the original detection results.
    * @return {Array} the detection results with named keypoints added.
    * @private
    */
-  addKeypoints(hands) {
-    const result = hands.map((hand) => {
-      hand.keypoints.forEach((keypoint) => {
-        hand[keypoint.name] = {
+  addKeypoints(poses) {
+    const result = poses.map((pose) => {
+      pose.keypoints.forEach((keypoint) => {
+        pose[keypoint.name] = {
           x: keypoint.x,
           y: keypoint.y,
           score: keypoint.score,
         };
-        if (keypoint.z) hand[keypoint.name].z = keypoint.z;
+        if (keypoint.z) pose[keypoint.name].z = keypoint.z;
       });
-      return hand;
+      return pose;
     });
     return result;
   }


### PR DESCRIPTION
The PR adds the `resizeBoundingBoxes` function, which resizes the bounding box values of `MoveNet` models relative to the media size.

I am also fixing some typos in the `addKeypoints` method where `hand` is supposed to be `pose`.