### PR TITLE
Tests for the neuralNetwork `addData` function.

### DIFF
--- a/src/NeuralNetwork/index.test.js
+++ b/src/NeuralNetwork/index.test.js
@@ -1,0 +1,160 @@
+import { asyncLoadImage, randomImageData } from '../utils/testingUtils';
+import neuralNetwork from './index';
+
+describe('Adding data to Neural Network', () => {
+  let nn;
+
+  const lastData = () =>
+    nn.neuralNetworkData.data.raw[nn.neuralNetworkData.data.raw.length - 1];
+
+  const warnSpy = jest.spyOn(console, 'warn');
+
+  describe('classification', () => {
+    describe('using property names for inputs and outputs', () => {
+      beforeAll(async () => {
+        return new Promise((resolve) => {
+          nn = neuralNetwork({
+            inputs: ['avg_temperature', 'humidity'],
+            outputs: ['rained'],
+            task: 'classification'
+          }, () => resolve());
+        });
+      });
+
+      it('creates a model', () => {
+        expect(nn.options.inputs).toHaveLength(2);
+        expect(nn.options.outputs).toHaveLength(1);
+        expect(nn.options.outputs[0]).toBe('rained');
+      });
+
+      it('can add data from a dictionary object', () => {
+        nn.addData({ "avg_temperature": 20, "humidity": 0.2 }, { "rained": "no" });
+        const added = lastData();
+        expect(added.xs.avg_temperature).toBe(20);
+        expect(added.xs.humidity).toBe(0.2);
+        expect(added.ys.rained).toBe('no');
+      });
+
+      // Currently fails
+      it.skip('ignores excess properties', () => {
+        // TODO: why do xs and ys need to be passed separately in this case?
+        const row = { "avg_temperature": 30, "humidity": 0.9, "rained": "yes" };
+        nn.addData(row, row);
+        const added = lastData();
+        expect(added.xs.humidity).toBe(0.9);
+        expect(added.xs.rained).toBeUndefined();
+        expect(added.ys.rained).toBe('yes');
+        expect(added.ys.humidity).toBeUndefined();
+      });
+
+      // Currently fails
+      it.skip('errors on missing properties', () => {
+        expect(() => {
+          nn.addData({}, { "rained": "yes" });
+        }).toThrow(); // TODO: check for a friendly message
+      });
+
+      it('can add data as an array', () => {
+        nn.addData([25, 0.3], ["no"]);
+        const added = lastData();
+        expect(added.xs.avg_temperature).toBe(25);
+        expect(added.xs.humidity).toBe(0.3);
+        expect(added.ys.rained).toBe('no');
+      });
+
+      // Currently fails
+      it.skip('errors on too few inputs', () => {
+        expect(() => {
+          nn.addData([25], ["no"]);
+        }).toThrow(); // TODO: check for a friendly message
+      });
+
+      // Currently fails
+      it.skip('warns on too many inputs', () => {
+        expect(() => {
+          nn.addData([1, 2, 3, 4, 5], ["no"]);
+        }).not.toThrow();
+        expect(warnSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('using numbers for inputs and outputs', () => {
+      beforeEach(async () => {
+        return new Promise((resolve) => {
+          nn = neuralNetwork({
+            inputs: 2,
+            outputs: 2,
+            task: 'classification'
+          }, () => resolve());
+        });
+      });
+
+      it('creates a model', () => {
+        expect(nn.options.inputs).toBe(2);
+        expect(nn.options.outputs).toBe(2);
+      });
+
+      it('can add data from a dictionary object', async () => {
+        nn.addData({ "avg_temperature": 25, "humidity": 0.3 }, { "rained": "no" });
+        const added = lastData();
+        expect(added.xs.avg_temperature).toBe(25);
+        expect(added.xs.humidity).toBe(0.3);
+        expect(added.ys.rained).toBe('no');
+        nn.addData({ "avg_temperature": 30, "humidity": 0.9 },{ "rained": "yes" });
+        await nn.train();
+        const guess = await nn.classify({ "avg_temperature": 20, "humidity": 0.4 });
+        expect(guess[0].label).toBe('no');
+        expect(guess[1].label).toBe('yes');
+      });
+
+      it('can add data as an array', async () => {
+        nn.addData([25, 0.3], ["no"]);
+        const added = lastData();
+        expect(added.xs['0']).toBe(25);
+        expect(added.xs['1']).toBe(0.3);
+        expect(added.ys['0']).toBe('no');
+        nn.addData([30, 0.9], ["yes"]);
+        await nn.train();
+        const guess = await nn.classify([20, 0.4]);
+        expect(guess[0].label).toBe('no');
+        expect(guess[1].label).toBe('yes');
+      });
+    });
+  });
+
+  // All currently fail
+  describe.skip('image classification', () => {
+    beforeAll(async () => {
+      nn = neuralNetwork({
+        task: 'imageClassification',
+        inputs: [32, 32, 3],
+        // outputs: ['label']
+        outputs: 2
+        // outputs: ['cat', 'dog']
+      });
+      await nn.ready;
+    });
+
+    it('can add HTML images', () => {
+      const dataSpy = jest.spyOn(nn.neuralNetworkData, 'addData');
+      const image = asyncLoadImage('https://cdn.jsdelivr.net/gh/ml5js/ml5-library@main/assets/bird.jpg');
+      nn.addData({ image: image }, { label: 'cat' });
+      expect(dataSpy).toHaveBeenCalledTimes(1);
+      expect(lastData().xs.image.length).toBe(32 * 32 * 3);
+      // TODO
+    });
+
+    it('can add untyped pixel arrays', () => {
+      nn.addData({ image: new Array(32 * 32 * 3).fill(0) }, { label: 'cat' });
+      nn.addData(new Array(32 * 32 * 3).fill(0), 'cat');
+      // TODO
+    });
+
+    it('can add typed pixel arrays', () => {
+      const imageData = randomImageData(32, 32);
+      nn.addData({ image: imageData.data }, { label: 'cat' });
+      nn.addData(imageData.data, 'cat');
+      // TODO
+    });
+  });
+});


### PR DESCRIPTION
This is a draft because there is a some obnoxious issue with and `import` statement in the `@tensorflow/tfjs-vis` package which causes Jest to crash while testing the `NeuralNetwork/index.js file`.  I had to comment out a few lines regarding the `NeuralNetworkVis` while working on the tests.  Make I can make a jest mock for the file?

```
    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    D:\projects\ml5.js\ml5-next-gen\node_modules\@tensorflow\tfjs-core\dist\public\chained_ops\register_all_chained_ops.js:17
    import './abs';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      1 | // import * as tf from '@tensorflow/tfjs';
    > 2 | import * as tfvis from "@tensorflow/tfjs-vis";
        | ^
      3 | // https://js.tensorflow.org/api_vis/latest/#render.barchart
      4 |
      5 | class NeuralNetworkVis {

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1505:14)
      at Object.<anonymous> (node_modules/@tensorflow/tfjs-vis/src/index.ts:19:1)
      at Object.require (src/NeuralNetwork/NeuralNetworkVis.js:2:1)
      at Object.require (src/NeuralNetwork/index.js:9:1)
      at Object.require (src/NeuralNetwork/index.test.js:2:1)
```

There are a bunch of tests which fail at the moment that are being ignored with `.skip`.  These are things that I would like to improve in the neural network code eventually, such as throwing errors on logging warnings on incomplete data.

  * classification
    * using property names for inputs and outputs
      * [x] creates a model
      * [x] can add data from a dictionary object
      * [ ] ignores excess properties
      * [ ] errors on missing properties
      * [x] can add data as an array
      * [ ] errors on too few inputs
      * [ ] warns on too many inputs
    * using numbers for inputs and outputs
      * [x] creates a model
      * [x] can add data from a dictionary object
      * [x] can add data as an array
  * image classification
    * [ ] can add HTML images
    * [ ] can add untyped pixel arrays
    * [ ] can add typed pixel arrays