### PR TITLE
bodyPose skeleton examples

### DIFF
--- a/examples/BodyPose-blazepose-skeleton/index.html
+++ b/examples/BodyPose-blazepose-skeleton/index.html
@@ -9,7 +9,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose BlazePose Skeleton Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-blazepose-skeleton/index.html
+++ b/examples/BodyPose-blazepose-skeleton/index.html
@@ -1,0 +1,19 @@
+<!--
+ Copyright (c) 2024 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ml5.js BodyPose BlazePose Skeleton Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/BodyPose-blazepose-skeleton/sketch.js
+++ b/examples/BodyPose-blazepose-skeleton/sketch.js
@@ -6,45 +6,7 @@
 let video;
 let bodyPose;
 let poses = [];
-
-let connections = [
-  [0, 1],
-  [0, 4],
-  [1, 2],
-  [2, 3],
-  [3, 7],
-  [4, 5],
-  [5, 6],
-  [6, 8],
-  [9, 10],
-  [11, 12],
-  [11, 13],
-  [11, 23],
-  [12, 14],
-  [14, 16],
-  [12, 24],
-  [13, 15],
-  [15, 17],
-  [16, 18],
-  [16, 20],
-  [15, 17],
-  [15, 19],
-  [15, 21],
-  [16, 22],
-  [17, 19],
-  [18, 20],
-  [23, 25],
-  [23, 24],
-  [24, 26],
-  [25, 27],
-  [26, 28],
-  [27, 29],
-  [28, 30],
-  [27, 31],
-  [28, 32],
-  [29, 31],
-  [30, 32],
-];
+let connections;
 
 function preload() {
   // Load the bodyPose model
@@ -61,6 +23,8 @@ function setup() {
 
   // Start detecting poses in the webcam video
   bodyPose.detectStart(video, gotPoses);
+  //get the skeleton connection information
+  connections = bodyPose.getSkeleton();
 }
 
 function draw() {

--- a/examples/BodyPose-blazepose-skeleton/sketch.js
+++ b/examples/BodyPose-blazepose-skeleton/sketch.js
@@ -1,0 +1,101 @@
+// Copyright (c) 2024 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+let video;
+let bodyPose;
+let poses = [];
+
+let connections = [
+  [0, 1],
+  [0, 4],
+  [1, 2],
+  [2, 3],
+  [3, 7],
+  [4, 5],
+  [5, 6],
+  [6, 8],
+  [9, 10],
+  [11, 12],
+  [11, 13],
+  [11, 23],
+  [12, 14],
+  [14, 16],
+  [12, 24],
+  [13, 15],
+  [15, 17],
+  [16, 18],
+  [16, 20],
+  [15, 17],
+  [15, 19],
+  [15, 21],
+  [16, 22],
+  [17, 19],
+  [18, 20],
+  [23, 25],
+  [23, 24],
+  [24, 26],
+  [25, 27],
+  [26, 28],
+  [27, 29],
+  [28, 30],
+  [27, 31],
+  [28, 32],
+  [29, 31],
+  [30, 32],
+];
+
+function preload() {
+  // Load the bodyPose model
+  bodyPose = ml5.bodyPose("BlazePose");
+}
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+
+  // Start detecting poses in the webcam video
+  bodyPose.detectStart(video, gotPoses);
+}
+
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+
+      stroke(255, 0, 0);
+      strokeWeight(2);
+      line(pointA.x, pointA.y, pointB.x, pointB.y);
+    }
+  }
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < pose.keypoints.length; j++) {
+      let keypoint = pose.keypoints[j];
+      fill(0, 255, 0);
+      noStroke();
+      circle(keypoint.x, keypoint.y, 10);
+    }
+  }
+}
+
+// Callback function for when bodyPose outputs data
+function gotPoses(results) {
+  // Save the output to the poses variable
+  poses = results;
+}

--- a/examples/BodyPose-skeleton/index.html
+++ b/examples/BodyPose-skeleton/index.html
@@ -9,7 +9,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose Skeleton Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-skeleton/index.html
+++ b/examples/BodyPose-skeleton/index.html
@@ -1,0 +1,19 @@
+<!--
+ Copyright (c) 2024 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ml5.js BodyPose Skeleton Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/BodyPose-skeleton/sketch.js
+++ b/examples/BodyPose-skeleton/sketch.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2024 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+let video;
+let bodyPose;
+let poses = [];
+
+let connections = [
+  [0, 1],
+  [0, 2],
+  [1, 3],
+  [2, 4],
+  [5, 6],
+  [5, 7],
+  [5, 11],
+  [6, 8],
+  [6, 12],
+  [7, 9],
+  [8, 10],
+  [11, 12],
+  [11, 13],
+  [12, 14],
+  [13, 15],
+  [14, 16],
+];
+
+function preload() {
+  // Load the bodyPose model
+  bodyPose = ml5.bodyPose();
+}
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+
+  // Start detecting poses in the webcam video
+  bodyPose.detectStart(video, gotPoses);
+}
+
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  //draw the skeleton connections
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < connections.length; j++) {
+      let pointAIndex = connections[j][0];
+      let pointBIndex = connections[j][1];
+      let pointA = pose.keypoints[pointAIndex];
+      let pointB = pose.keypoints[pointBIndex];
+      // Only draw a line if both points are confident enough
+      if (pointA.score > 0.1 && pointB.score > 0.1) {
+        stroke(255, 0, 0);
+        strokeWeight(2);
+        line(pointA.x, pointA.y, pointB.x, pointB.y);
+      }
+    }
+  }
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < pose.keypoints.length; j++) {
+      let keypoint = pose.keypoints[j];
+      // Only draw a circle if the keypoint's confidence is bigger than 0.1
+      if (keypoint.score > 0.1) {
+        fill(0, 255, 0);
+        noStroke();
+        circle(keypoint.x, keypoint.y, 10);
+      }
+    }
+  }
+}
+
+// Callback function for when bodyPose outputs data
+function gotPoses(results) {
+  // Save the output to the poses variable
+  poses = results;
+}

--- a/examples/BodyPose-skeleton/sketch.js
+++ b/examples/BodyPose-skeleton/sketch.js
@@ -6,25 +6,7 @@
 let video;
 let bodyPose;
 let poses = [];
-
-let connections = [
-  [0, 1],
-  [0, 2],
-  [1, 3],
-  [2, 4],
-  [5, 6],
-  [5, 7],
-  [5, 11],
-  [6, 8],
-  [6, 12],
-  [7, 9],
-  [8, 10],
-  [11, 12],
-  [11, 13],
-  [12, 14],
-  [13, 15],
-  [14, 16],
-];
+let connections;
 
 function preload() {
   // Load the bodyPose model
@@ -41,6 +23,8 @@ function setup() {
 
   // Start detecting poses in the webcam video
   bodyPose.detectStart(video, gotPoses);
+  //get the skeleton connection information
+  connections = bodyPose.getSkeleton();
 }
 
 function draw() {

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -378,6 +378,22 @@ class BodyPose {
       return false;
     return true;
   }
+
+  /**
+   * Returns the skeleton connections pairs for the model.
+   * @returns {Number[][]} an array of pairs of indices containing the connected keypoints.
+   */
+  getSkeleton() {
+    if (this.modelName === "BlazePose") {
+      return poseDetection.util.getAdjacentPairs(
+        poseDetection.SupportedModels.BlazePose
+      );
+    } else {
+      return poseDetection.util.getAdjacentPairs(
+        poseDetection.SupportedModels.MoveNet
+      );
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR adds example p5 sketches that draw skeletons for the `MoveNet` and `BlazePose` models. 

~~The [nested arrays that define the skeletal connections](https://github.com/tensorflow/tfjs-models/blob/c5fcabec4cc0335bdfabeb14dc2adfd6ef0cde8c/pose-detection/src/constants.ts#L72) are copied into the p5 sketches and iterated over to draw the skeleton lines.~~

As @lindapaiste suggested, I added a new `getSkeleton` function to `bodyPose` that re-exports the skeleton data from tfjs. There's probably a better name than `getSkeleton` though.