### PR TITLE
Create `/tests` folder, remove `canvas` polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ website/i18n/*
 yarn-error.log
 local.log
 
-coverage/*
+tests/coverage/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 /dist
-/coverage
+/tests/coverage

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "webpack serve --config webpack.config.js --mode development",
     "format": "prettier --write \"**/*.js\"",
     "postinstall": "patch-package",
-    "test": "jest"
+    "test": "jest --config tests/jest.config.js"
   },
   "files": [
     "dist"
@@ -33,7 +33,6 @@
     "@tensorflow/tfjs-node": "^4.17.0",
     "all-contributors-cli": "^6.26.1",
     "babel-jest": "^29.7.0",
-    "canvas": "^2.11.2",
     "cross-fetch": "^4.0.0",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
@@ -60,7 +59,11 @@
     "@tensorflow/tfjs": "^4.2.0",
     "@tensorflow/tfjs-vis": "^1.5.1",
     "axios": "^1.3.4",
-    "canvas": "^2.11.2",
     "webpack-merge": "^5.9.0"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env"
+    ]
   }
 }

--- a/tests/integration/bodyPose.test.js
+++ b/tests/integration/bodyPose.test.js
@@ -3,14 +3,15 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { asyncLoadImage } from "../utils/testingUtils";
-import bodyPose from "./index";
+import { asyncLoadImage } from "../testingUtils";
+import bodyPose from "../../src/Bodypose";
 import crossFetch from "cross-fetch";
 
 const POSENET_IMG =
   "https://github.com/ml5js/ml5-adjacent/raw/master/02_ImageClassification_Video/starter.png";
 
-describe("bodypose", () => {
+// TODO: run this in a browser
+describe.skip("bodypose", () => {
   let myBodyPose;
   let image;
 

--- a/tests/integration/handPose.test.js
+++ b/tests/integration/handPose.test.js
@@ -4,12 +4,13 @@
 // https://opensource.org/licenses/MIT
 
 import crossFetch from 'cross-fetch';
-import { asyncLoadImage } from "../utils/testingUtils";
-import handpose from "./index";
+import { asyncLoadImage } from "../testingUtils";
+import handpose from "../../src/Handpose";
 
 const HANDPOSE_IMG = "https://i.imgur.com/EZXOjqh.jpg";
 
-describe("Handpose", () => {
+// TODO: run this in a browser
+describe.skip("Handpose", () => {
   let handposeInstance;
   let testImage;
 

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -6,15 +6,17 @@
 /** @type {import('jest').Config} */
 const config = {
   collectCoverage: true,
-  coverageDirectory: "coverage",
+  coverageDirectory: "<rootDir>/tests/coverage",
   coverageProvider: "v8",
-  globalSetup: "./setupTests.js",
+  globalSetup: "<rootDir>/tests/testingUtils/setupTests.js",
   passWithNoTests: true,
   testEnvironment: "jsdom",
   testEnvironmentOptions: {
     resources: "usable", // Load image resources
   },
-  resetMocks: true
+  resetMocks: true,
+  rootDir: "..", // Set the rootDir to the project root so that transforms will apply to source code in /src
+  roots: ["<rootDir>/tests/unit"] // Only run the unit tests
 };
 
 module.exports = config;

--- a/tests/testingUtils/index.js
+++ b/tests/testingUtils/index.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { createImageData, ImageData } from "canvas";
-
 export const asyncLoadImage = async (src) => {
   const img = new Image();
   if (src.startsWith("http")) {
@@ -26,11 +23,6 @@ export const randomImageData = (width = 200, height = 100) => {
     Math.floor(Math.random() * 256)
   );
   // Initialize a new ImageData object
-  return createImageData(array, width, height);
+  return { width, height, data: array };
 };
 
-export const polyfillImageData = () => {
-  if (!global.ImageData) {
-    global.ImageData = ImageData;
-  }
-};

--- a/tests/testingUtils/setupTests.js
+++ b/tests/testingUtils/setupTests.js
@@ -1,4 +1,3 @@
-const { ImageData } = require("canvas");
 import '@tensorflow/tfjs-node'; // loads the tensorflow/node backend to the registry
 import crossFetch from 'cross-fetch';
 import * as tf from '@tensorflow/tfjs';
@@ -10,11 +9,6 @@ async function setupTests() {
   await tf.setBackend('tensorflow');
   tf.env().set('IS_BROWSER', false);
   tf.env().set('IS_NODE', true);
-
-  // Use the node-canvas ImageData polyfill
-  if (!global.ImageData) {
-    global.ImageData = ImageData;
-  }
 
   // Use cross-fetch as a polyfill for the browser fetch
   if (!global.fetch) {

--- a/tests/unit/handleOptions.test.js
+++ b/tests/unit/handleOptions.test.js
@@ -1,4 +1,4 @@
-import handleOptions from './handleOptions';
+import handleOptions from '../../src/utils/handleOptions';
 
 describe('handleOptions', () => {
   const warnSpy = jest.spyOn(console, 'warn');

--- a/tests/unit/modelLoader.test.js
+++ b/tests/unit/modelLoader.test.js
@@ -1,4 +1,4 @@
-import modelLoader, { isAbsoluteURL } from './modelLoader';
+import modelLoader, { isAbsoluteURL } from '../../src/utils/modelLoader';
 
 describe('isAbsoluteURL', () => {
   it('returns false if relative', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,20 +1158,6 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@mapbox/node-pre-gyp@^1.0.0":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
-  dependencies:
-    detect-libc "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.7"
-    nopt "^5.0.0"
-    npmlog "^5.0.1"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.11"
-
 "@mediapipe/face_mesh@^0.4.1633559619":
   version "0.4.1633559619"
   resolved "https://registry.yarnpkg.com/@mediapipe/face_mesh/-/face_mesh-0.4.1633559619.tgz#f917e4448e25bc375a905d1d910f1bca450c5e23"
@@ -2197,14 +2183,6 @@ caniuse-lite@^1.0.30001587:
   version "1.0.30001596"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz#da06b79c3d9c3d9958eb307aa832ac68ead79bee"
 
-canvas@^2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.2.tgz#553d87b1e0228c7ac0fc72887c3adbac4abbd860"
-  dependencies:
-    "@mapbox/node-pre-gyp" "^1.0.0"
-    nan "^2.17.0"
-    simple-get "^3.0.3"
-
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2729,12 +2707,6 @@ decamelize@^1.2.0:
 decimal.js@^10.4.2:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
-
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  dependencies:
-    mimic-response "^2.0.0"
 
 dedent@^1.0.0:
   version "1.5.1"
@@ -4317,10 +4289,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -4407,10 +4375,6 @@ multicast-dns@^7.2.5:
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-
-nan@^2.17.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4523,7 +4487,7 @@ on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
 
-once@^1.3.0, once@^1.3.1:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -5146,18 +5110,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
 signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
-
-simple-concat@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
-
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Fixes #97 
Implements @gohai's recommendations in https://github.com/ml5js/ml5-next-gen/pull/82#issuecomment-2010919727

Changes: 
- Move all test-related code to a new folder `/tests`.
  - Move the `/coverage` folder.
  - Move the jest configuration file (`jest.config.js`).
    - Specify the location in `package.json` since it is no longer at the root.
    - Adjust the paths in the config using `<rootDir>` syntax.
  - Use jest only on the `/unit` folder.
  - Add an `/integration` folder for tests requiring a browser.  These are not run at the moment and will need to be set up in a future PR.
- Uninstall `canvas` package - fixes #97 
  - Remove the polyfill from the `setupTests.js` file. 
  - Move files which involve reading an image into the `/integration` folder.
- Delete Babel config files and put the config in `package.json`.