### PR TITLE
Update webpack build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ml5",
   "version": "0.20.0-alpha.3",
   "description": "A friendly machine learning library for the web.",
-  "main": "dist/ml5.js",
+  "main": "dist/ml5.min.js",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "webpack --config webpack.config.js --mode production",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postinstall-postinstall": "^2.1.0",
     "prettier": "2.8.8",
     "rimraf": "^5.0.5",
+    "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.76.1",
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.15.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,13 @@
 const { resolve } = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { merge } = require("webpack-merge");
+const TerserPlugin = require("terser-webpack-plugin");
 
 const commonConfig = {
   context: __dirname,
   entry: "./src/index.js",
   output: {
-    filename: "ml5.min.js",
+    filename: "ml5.js",
     path: resolve(__dirname, "dist"),
     library: {
       name: "ml5",
@@ -48,9 +49,24 @@ const developmentConfig = {
 
 const productionConfig = {
   mode: "production",
+  entry: {
+    ml5: "./src/index.js",
+    "ml5.min": "./src/index.js",
+  },
   devtool: "source-map",
   output: {
     publicPath: "/",
+    filename: "[name].js",
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        include: "ml5.min.js",
+        exclude: "ml5.js",
+        extractComments: false,
+      }),
+    ],
   },
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const commonConfig = {
   context: __dirname,
   entry: "./src/index.js",
   output: {
-    filename: "ml5.js",
+    filename: "ml5.min.js",
     path: resolve(__dirname, "dist"),
     library: {
       name: "ml5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,7 +1126,7 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   dependencies:
@@ -5348,6 +5348,17 @@ tar@^6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+terser-webpack-plugin@^5.3.10:
+  version "5.3.10"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
+  integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.20"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.1"
+    terser "^5.26.0"
+
 terser-webpack-plugin@^5.3.7:
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
@@ -5361,6 +5372,16 @@ terser-webpack-plugin@^5.3.7:
 terser@^5.10.0, terser@^5.16.8:
   version "5.19.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.1.tgz#dbd7231f224a9e2401d0f0959542ed74d76d340b"
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.26.0:
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.29.2.tgz#c17d573ce1da1b30f21a877bffd5655dd86fdb35"
+  integrity sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
The PR updates Webpack configuration so it outputs both `ml5.js` and `ml5.min.js` when in production mode. The `main` property in `package.json` is also changed to `dist/ml5.min.js` per the original ml5 library.

Could someone familiar with Webpack take a closer look at this PR since I am not too experienced with it?