### PR TITLE
Fix unnecessary mapping when loading from a FileList

### DIFF
--- a/src/NeuralNetwork/NeuralNetwork.js
+++ b/src/NeuralNetwork/NeuralNetwork.js
@@ -205,26 +205,10 @@ class NeuralNetwork {
    */
   async load(filesOrPath) {
     if (filesOrPath instanceof FileList) {
-      const files = await Promise.all(
-        Array.from(filesOrPath).map(async (file) => {
-          if (file.name.includes(".json") && !file.name.includes("_meta")) {
-            return { name: "model", file };
-          } else if (
-            file.name.includes(".json") &&
-            file.name.includes("_meta.json")
-          ) {
-            const modelMetadata = await file.text();
-            return { name: "metadata", file: modelMetadata };
-          } else if (file.name.includes(".bin")) {
-            return { name: "weights", file };
-          }
-          return { name: null, file: null };
-        })
-      );
-
-      const model = files.find((item) => item.name === "model").file;
-      const weights = files.find((item) => item.name === "weights").file;
-
+      const files = Array.from(filesOrPath);
+      // find the correct files
+      const model = files.find((file) => file.name.includes(".json") && !file.name.includes("_meta"));
+      const weights = files.find((file) => file.name.includes(".bin"));
       // load the model
       this.model = await tf.loadLayersModel(
         tf.io.browserFiles([model, weights])


### PR DESCRIPTION
I haven't actually tested this out.

Background:
There are some things in the code that are very silly.  The `NeuralNetwork` is actually loading the metadata file with `await file.text();` even though it does not use it.  The `NeuralNetworkData` looks for all three of `"model"`, `"metadata"`, and `"weights"` even though it only needs `"metadata"`.

Changes:
- Remove the mapping of `File` objects to `{ name, file }` objects.
- Find the correct file(s) by using `.find()` directly on the array of `File` objects, using the same `file.name` conditions as before.
- Add a warning if the `FileList` does not contain a `_meta.json` file.
- Use the `modelLoader` utility to handle modifying the path.
- Changed this line `modelMetadata = modelMetadata.data;` where we assign a different value (of a different type) to the same variable because I hate it.

---

Future TODO:
- Adapt the `ModelLoader` utility to handle more situations, such as non-standard file names and passing multiple files.
- We are using the filename `"model_meta.json"` when a `string` is provided but this won't be right 100% of the time because we save the file as `${modelName}_meta.json`.
- Include more errors and/or warnings using `try`/`catch` blocks.
- Investigate how we can use the [`userDefinedMetadata` property](https://github.com/tensorflow/tfjs/blob/f0f981fe306bf548e300536aca485c0ffdd6619e/tfjs-core/src/io/types.ts#L372-L375) to include our meta inside the TFJS `model.json` file. (this would be a breaking change)
- Figure out how to pass fetched data to TFJS using the `IOHandler` interface without [converting to a `File` object](https://github.com/ml5js/ml5-next-gen/blob/360d14f6e12f7766e9fd5daec3fc0d826f7da86d/src/NeuralNetwork/NeuralNetwork.js#L238-L255).