### PR TITLE
Update example headers and p5 version

### DIFF
--- a/examples/BodyPose-blazepose-keypoints/index.html
+++ b/examples/BodyPose-blazepose-keypoints/index.html
@@ -3,13 +3,13 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates pose tracking on live video through ml5.bodyPose.
+  This example demonstrates pose tracking on live video through ml5.bodyPose with BlazePose model.
 -->
 
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>ml5.js BodyPose Blazepose Detection Example</title>
+    <title>ml5.js bodyPose BlazePose Detection Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodyPose-blazepose-keypoints/index.html
+++ b/examples/BodyPose-blazepose-keypoints/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2018-2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates pose tracking on live video through ml5.bodyPose.
 -->
 
 <html>

--- a/examples/BodyPose-blazepose-keypoints/index.html
+++ b/examples/BodyPose-blazepose-keypoints/index.html
@@ -10,7 +10,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose Blazepose Detection Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-blazepose-keypoints/sketch.js
+++ b/examples/BodyPose-blazepose-keypoints/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2018-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates pose tracking on live video through ml5.bodyPose.
+ */
 
 let video;
 let bodyPose;

--- a/examples/BodyPose-blazepose-keypoints/sketch.js
+++ b/examples/BodyPose-blazepose-keypoints/sketch.js
@@ -3,7 +3,7 @@
  * Learn more about the ml5.js project: https://ml5js.org/
  * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
  *
- * This example demonstrates pose tracking on live video through ml5.bodyPose.
+ * This example demonstrates pose tracking on live video through ml5.bodyPose with BlazePose model
  */
 
 let video;

--- a/examples/BodyPose-blazepose-skeleton/index.html
+++ b/examples/BodyPose-blazepose-skeleton/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2024 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates drawing skeletons on poses with ml5.bodyPose.
 -->
 
 <html>

--- a/examples/BodyPose-blazepose-skeleton/index.html
+++ b/examples/BodyPose-blazepose-skeleton/index.html
@@ -3,13 +3,13 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+  This example demonstrates drawing skeletons on poses for the BlazePose model.
 -->
 
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>ml5.js BodyPose BlazePose Skeleton Example</title>
+    <title>ml5.js bodyPose BlazePose Skeleton Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodyPose-blazepose-skeleton/index.html
+++ b/examples/BodyPose-blazepose-skeleton/index.html
@@ -10,7 +10,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose BlazePose Skeleton Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-blazepose-skeleton/sketch.js
+++ b/examples/BodyPose-blazepose-skeleton/sketch.js
@@ -3,7 +3,7 @@
  * Learn more about the ml5.js project: https://ml5js.org/
  * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
  *
- * This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+ * This example demonstrates drawing skeletons on poses for the BlazePose model.
  */
 
 let video;

--- a/examples/BodyPose-blazepose-skeleton/sketch.js
+++ b/examples/BodyPose-blazepose-skeleton/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2024 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+ */
 
 let video;
 let bodyPose;

--- a/examples/BodyPose-keypoints/index.html
+++ b/examples/BodyPose-keypoints/index.html
@@ -9,7 +9,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>ml5.js BodyPose Detection Example</title>
+    <title>ml5.js bodyPose Detection Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodyPose-keypoints/index.html
+++ b/examples/BodyPose-keypoints/index.html
@@ -3,7 +3,7 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates pose tracking on live video through ml5.bodyPose.
+  This example demonstrates pose tracking on live video through ml5.bodyPose with MoveNet model.
 -->
 
 <html>

--- a/examples/BodyPose-keypoints/index.html
+++ b/examples/BodyPose-keypoints/index.html
@@ -10,7 +10,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose Detection Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-keypoints/index.html
+++ b/examples/BodyPose-keypoints/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2018-2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates pose tracking on live video through ml5.bodyPose.
 -->
 
 <html>

--- a/examples/BodyPose-keypoints/sketch.js
+++ b/examples/BodyPose-keypoints/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2018-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates pose tracking on live video through ml5.bodyPose.
+ */
 
 let video;
 let bodyPose;

--- a/examples/BodyPose-keypoints/sketch.js
+++ b/examples/BodyPose-keypoints/sketch.js
@@ -3,7 +3,7 @@
  * Learn more about the ml5.js project: https://ml5js.org/
  * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
  *
- * This example demonstrates pose tracking on live video through ml5.bodyPose.
+ * This example demonstrates pose tracking on live video through ml5.bodyPose with MoveNet model.
  */
 
 let video;

--- a/examples/BodyPose-skeleton/index.html
+++ b/examples/BodyPose-skeleton/index.html
@@ -3,13 +3,13 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+  This example demonstrates drawing skeletons on poses for the MoveNet model.
 -->
 
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>ml5.js BodyPose Skeleton Example</title>
+    <title>ml5.js bodyPose Skeleton Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodyPose-skeleton/index.html
+++ b/examples/BodyPose-skeleton/index.html
@@ -10,7 +10,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>ml5.js BodyPose Skeleton Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/BodyPose-skeleton/index.html
+++ b/examples/BodyPose-skeleton/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2024 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates drawing skeletons on poses with ml5.bodyPose.
 -->
 
 <html>

--- a/examples/BodyPose-skeleton/sketch.js
+++ b/examples/BodyPose-skeleton/sketch.js
@@ -3,7 +3,7 @@
  * Learn more about the ml5.js project: https://ml5js.org/
  * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
  *
- * This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+ * This example demonstrates drawing skeletons on poses for the MoveNet model.
  */
 
 let video;

--- a/examples/BodyPose-skeleton/sketch.js
+++ b/examples/BodyPose-skeleton/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2024 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates drawing skeletons on poses with ml5.bodyPose.
+ */
 
 let video;
 let bodyPose;

--- a/examples/BodySegmentation-maskbackground/index.html
+++ b/examples/BodySegmentation-maskbackground/index.html
@@ -1,10 +1,18 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates separating a person from the background with ml5.bodySegmentation.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>BodySegmentation Mask Background Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskbackground/index.html
+++ b/examples/BodySegmentation-maskbackground/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BodySegmentation Mask Background Example</title>
+    <title>ml5.js bodySegmentation Mask Background Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskbackground/index.html
+++ b/examples/BodySegmentation-maskbackground/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BodySegmentation Mask Background Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/BodySegmentation-maskbackground/sketch.js
+++ b/examples/BodySegmentation-maskbackground/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2020-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates separating people from the background with ml5.bodySegmentation.
+ */
 
 let bodyPix;
 let video;

--- a/examples/BodySegmentation-maskbodyparts/index.html
+++ b/examples/BodySegmentation-maskbodyparts/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BodySegmentation Parts Example</title>
+    <title>ml5.js bodySegmentation Parts Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskbodyparts/index.html
+++ b/examples/BodySegmentation-maskbodyparts/index.html
@@ -1,10 +1,18 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates segmenting a person by body parts with ml5.bodySegmentation.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>BodySegmentation Parts Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskbodyparts/index.html
+++ b/examples/BodySegmentation-maskbodyparts/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BodySegmentation Parts Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/BodySegmentation-maskbodyparts/sketch.js
+++ b/examples/BodySegmentation-maskbodyparts/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2020-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates segmenting a person by body parts with ml5.bodySegmentation.
+ */
 
 let bodyPix;
 let video;

--- a/examples/BodySegmentation-maskperson/index.html
+++ b/examples/BodySegmentation-maskperson/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BodySegmentation Mask Person Example</title>
+    <title>ml5.js bodySegmentation Mask Person Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskperson/index.html
+++ b/examples/BodySegmentation-maskperson/index.html
@@ -1,10 +1,18 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates segmenting the background from a person with ml5.bodySegmentation.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>BodySegmentation Mask Person Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/BodySegmentation-maskperson/index.html
+++ b/examples/BodySegmentation-maskperson/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BodySegmentation Mask Person Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/BodySegmentation-maskperson/sketch.js
+++ b/examples/BodySegmentation-maskperson/sketch.js
@@ -1,12 +1,10 @@
-// Copyright (c) 2020-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
-
-/* ===
-ml5 Example
-BodyPix
-=== */
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates segmenting the background from a person with ml5.bodySegmentation.
+ */
 
 let bodyPix;
 let video;

--- a/examples/FaceMesh-keypoints/index.html
+++ b/examples/FaceMesh-keypoints/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js faceMesh Webcam Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/FaceMesh-keypoints/index.html
+++ b/examples/FaceMesh-keypoints/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates face tracking on live video through ml5.faceMesh.
 -->
 
 <!DOCTYPE html>
@@ -11,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js FaceMesh p5 Webcam Example</title>
+    <title>ml5.js faceMesh Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/FaceMesh-keypoints/sketch.js
+++ b/examples/FaceMesh-keypoints/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates face tracking on live video through ml5.faceMesh.
+ */
 
 let faceMesh;
 let video;

--- a/examples/FaceMesh-parts/index.html
+++ b/examples/FaceMesh-parts/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js FaceMesh p5 Webcam Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/FaceMesh-parts/index.html
+++ b/examples/FaceMesh-parts/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js FaceMesh p5 Webcam Example</title>
+    <title>ml5.js faceMesh p5 Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/FaceMesh-parts/index.html
+++ b/examples/FaceMesh-parts/index.html
@@ -1,9 +1,11 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates tracking a particular face feature through ml5.faceMesh.
 -->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/FaceMesh-parts/sketch.js
+++ b/examples/FaceMesh-parts/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates tracking a particular face feature through ml5.faceMesh.
+ */
 
 let faceMesh;
 let video;

--- a/examples/FaceMesh-single-image/index.html
+++ b/examples/FaceMesh-single-image/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js FaceMesh Image Example</title>
+    <title>ml5.js faceMesh Image Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/FaceMesh-single-image/index.html
+++ b/examples/FaceMesh-single-image/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates face tracking on an image through ml5.faceMesh.
 -->
 
 <!DOCTYPE html>
@@ -11,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js FaceMesh p5 Image Example</title>
+    <title>ml5.js FaceMesh Image Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/FaceMesh-single-image/index.html
+++ b/examples/FaceMesh-single-image/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js FaceMesh Image Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/FaceMesh-single-image/sketch.js
+++ b/examples/FaceMesh-single-image/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates face tracking on an image through ml5.faceMesh.
+ */
 
 let faceMesh;
 let img;

--- a/examples/HandPose-keypoints/index.html
+++ b/examples/HandPose-keypoints/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates hand tracking on live video through ml5.handPose.
 -->
 
 <!DOCTYPE html>
@@ -11,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose p5 Webcam Example</title>
+    <title>ml5.js HandPose Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-keypoints/index.html
+++ b/examples/HandPose-keypoints/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose Webcam Example</title>
+    <title>ml5.js handPose Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-keypoints/index.html
+++ b/examples/HandPose-keypoints/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js HandPose Webcam Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/HandPose-keypoints/sketch.js
+++ b/examples/HandPose-keypoints/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates hand tracking on live video through ml5.handPose.
+ */
 
 let handPose;
 let video;

--- a/examples/HandPose-parts/index.html
+++ b/examples/HandPose-parts/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates tracking particular parts of the hand through ml5.handPose.
 -->
 
 <!DOCTYPE html>

--- a/examples/HandPose-parts/index.html
+++ b/examples/HandPose-parts/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js HandPose p5 Webcam Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/HandPose-parts/index.html
+++ b/examples/HandPose-parts/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose p5 Webcam Example</title>
+    <title>ml5.js handPose p5 Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-parts/sketch.js
+++ b/examples/HandPose-parts/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates tracking particular parts of the hand through ml5.handPose.
+ */
 
 let handPose;
 let video;

--- a/examples/HandPose-single-image/index.html
+++ b/examples/HandPose-single-image/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose Image Example</title>
+    <title>ml5.js handPose Image Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-single-image/index.html
+++ b/examples/HandPose-single-image/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js HandPose Image Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/HandPose-single-image/index.html
+++ b/examples/HandPose-single-image/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates hand tracking on an image through ml5.handPose.
 -->
 
 <!DOCTYPE html>
@@ -11,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose p5 Image Example</title>
+    <title>ml5.js HandPose Image Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-single-image/sketch.js
+++ b/examples/HandPose-single-image/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates hand tracking on an image through ml5.handPose.
+ */
 
 let handPose;
 let video;

--- a/examples/HandPose-start-stop/index.html
+++ b/examples/HandPose-start-stop/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js HandPose p5 Start and Stop Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/HandPose-start-stop/index.html
+++ b/examples/HandPose-start-stop/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates the detectStart and detectStop API of ml5.handPose.
 -->
 
 <!DOCTYPE html>

--- a/examples/HandPose-start-stop/index.html
+++ b/examples/HandPose-start-stop/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js HandPose p5 Start and Stop Example</title>
+    <title>ml5.js handPose Start and Stop Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/HandPose-start-stop/sketch.js
+++ b/examples/HandPose-start-stop/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates the detectStart and detectStop API of ml5.handPose.
+ */
 
 let handPose;
 let video;

--- a/examples/ImageClassifier-video/index.html
+++ b/examples/ImageClassifier-video/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Webcam Image Classifier Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/ImageClassifier-video/index.html
+++ b/examples/ImageClassifier-video/index.html
@@ -1,3 +1,11 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates detecting objects in a live video through ml5.imageClassifier.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/ImageClassifier-video/index.html
+++ b/examples/ImageClassifier-video/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Webcam Image Classifier Example</title>
+    <title>ml5.js imageClassifier Webcam Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/ImageClassifier-video/sketch.js
+++ b/examples/ImageClassifier-video/sketch.js
@@ -1,14 +1,10 @@
-// Copyright (c) 2019 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
-
-/* ===
-ml5 Example
-Webcam video classification using MobileNet and p5.js
-This example uses a callback function to update the canvas label with the latest results,
-it makes use of the p5 mousePressed() function to toggle between an active classification
-=== */
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates detecting objects in a live video through ml5.imageClassifier.
+ */
 
 // A variable to initialize the Image Classifier
 let classifier;

--- a/examples/ImageClassifier/index.html
+++ b/examples/ImageClassifier/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Image Classifier Example</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/ImageClassifier/index.html
+++ b/examples/ImageClassifier/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Image Classifier Example</title>
+    <title>ml5.js imageClassifier Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/ImageClassifier/index.html
+++ b/examples/ImageClassifier/index.html
@@ -1,3 +1,11 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates detecting objects in an image through ml5.imageClassifier.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/examples/ImageClassifier/sketch.js
+++ b/examples/ImageClassifier/sketch.js
@@ -1,13 +1,10 @@
-// Copyright (c) 2019 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
-
-/* ===
-ml5 Example
-Image classification using MobileNet and p5.js
-This example uses a callback pattern to create the classifier
-=== */
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates detecting objects in an image through ml5.imageClassifier.
+ */
 
 // Initialize the Image Classifier method with MobileNet. A callback needs to be passed.
 let classifier;

--- a/examples/NeuralNetwork-color-classifier/index.html
+++ b/examples/NeuralNetwork-color-classifier/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js Neural Network Color Classifier</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuralNetwork-color-classifier/index.html
+++ b/examples/NeuralNetwork-color-classifier/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js Neural Network Color Classifier</title>
+    <title>ml5.js neuralNetwork Color Classifier Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuralNetwork-color-classifier/index.html
+++ b/examples/NeuralNetwork-color-classifier/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates training a color classifier through ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuralNetwork-color-classifier/sketch.js
+++ b/examples/NeuralNetwork-color-classifier/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates training a color classifier through ml5.neuralNetwork.
+ */
 
 // Step 1: load data or create some data
 let data = [

--- a/examples/NeuralNetwork-load/index.html
+++ b/examples/NeuralNetwork-load/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js Neural Network Loading Pre-trained Model</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuralNetwork-load/index.html
+++ b/examples/NeuralNetwork-load/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js Neural Network Loading Pre-trained Model</title>
+    <title>ml5.js neuralNetwork Loading Pre-trained Model Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuralNetwork-load/index.html
+++ b/examples/NeuralNetwork-load/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2024 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates loading a pre-trained model with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuralNetwork-load/sketch.js
+++ b/examples/NeuralNetwork-load/sketch.js
@@ -1,9 +1,10 @@
-// Copyright (c) 2024 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
-
-// This example will load a pre-trained model that recognizes hand gestures for rock paper scissors.
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates loading a pre-trained model with ml5.neuralNetwork.
+ */
 
 let classifier;
 let handPose;

--- a/examples/NeuralNetwork-mouse-gesture/index.html
+++ b/examples/NeuralNetwork-mouse-gesture/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js Neural Network Gesture Classifier</title>
+    <title>ml5.js neuralNetwork Gesture Classifier Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuralNetwork-mouse-gesture/index.html
+++ b/examples/NeuralNetwork-mouse-gesture/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates training a mouse gesture classifier with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuralNetwork-mouse-gesture/index.html
+++ b/examples/NeuralNetwork-mouse-gesture/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js Neural Network Gesture Classifier</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuralNetwork-mouse-gesture/sketch.js
+++ b/examples/NeuralNetwork-mouse-gesture/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates training a mouse gesture classifier with ml5.neuralNetwork.
+ */
 
 // Step 1: load data or create some data
 let data = [

--- a/examples/NeuralNetwork-train-and-save/index.html
+++ b/examples/NeuralNetwork-train-and-save/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js Neural Network Training and Saving Examples</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuralNetwork-train-and-save/index.html
+++ b/examples/NeuralNetwork-train-and-save/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js Neural Network Training and Saving Examples</title>
+    <title>ml5.js neuralNetwork Training and Saving Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuralNetwork-train-and-save/index.html
+++ b/examples/NeuralNetwork-train-and-save/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2024 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates training and saving an ml5.neuralNetwork model.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuralNetwork-train-and-save/sketch.js
+++ b/examples/NeuralNetwork-train-and-save/sketch.js
@@ -1,9 +1,10 @@
-// Copyright (c) 2024 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
-
-// This example will train a neural network to recognize hand gestures for rock paper scissors.
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates training and saving an ml5.neuralNetwork model.
+ */
 
 let classifier;
 let handPose;

--- a/examples/NeuroEvolution-flappy-bird/bird.js
+++ b/examples/NeuroEvolution-flappy-bird/bird.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Bird {
   constructor(brain) {

--- a/examples/NeuroEvolution-flappy-bird/index.html
+++ b/examples/NeuroEvolution-flappy-bird/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js NeuroEvolution Flappy Bird</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuroEvolution-flappy-bird/index.html
+++ b/examples/NeuroEvolution-flappy-bird/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates neuroevolution with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuroEvolution-flappy-bird/index.html
+++ b/examples/NeuroEvolution-flappy-bird/index.html
@@ -3,7 +3,7 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates neuroevolution with ml5.neuralNetwork.
+  This example demonstrates neuroevolutionary Flappy Bird with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js NeuroEvolution Flappy Bird</title>
+    <title>ml5.js neuralNetwork Neuroevolution Flappy Bird</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuroEvolution-flappy-bird/pipe.js
+++ b/examples/NeuroEvolution-flappy-bird/pipe.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Pipe {
   constructor() {

--- a/examples/NeuroEvolution-flappy-bird/sketch.js
+++ b/examples/NeuroEvolution-flappy-bird/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 let birds = [];
 let pipes = [];

--- a/examples/NeuroEvolution-sensors/creature.js
+++ b/examples/NeuroEvolution-sensors/creature.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Creature {
   constructor(x, y, brain) {

--- a/examples/NeuroEvolution-sensors/food.js
+++ b/examples/NeuroEvolution-sensors/food.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Food {
   constructor() {

--- a/examples/NeuroEvolution-sensors/index.html
+++ b/examples/NeuroEvolution-sensors/index.html
@@ -3,7 +3,7 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates neuroevolution with ml5.neuralNetwork.
+  This example demonstrates a neuroevolutionary ecosystem with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js NeuroEvolution Sensors</title>
+    <title>ml5.js neuralNetwork Neuroevolution Sensors</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuroEvolution-sensors/index.html
+++ b/examples/NeuroEvolution-sensors/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates neuroevolution with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuroEvolution-sensors/index.html
+++ b/examples/NeuroEvolution-sensors/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js NeuroEvolution Sensors</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuroEvolution-sensors/sensor.js
+++ b/examples/NeuroEvolution-sensors/sensor.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Sensor {
   constructor(v) {

--- a/examples/NeuroEvolution-sensors/sketch.js
+++ b/examples/NeuroEvolution-sensors/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 let bloops = [];
 let timeSlider;

--- a/examples/NeuroEvolution-steering/creature.js
+++ b/examples/NeuroEvolution-steering/creature.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Creature {
   constructor(x, y, brain) {

--- a/examples/NeuroEvolution-steering/glow.js
+++ b/examples/NeuroEvolution-steering/glow.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 class Glow {
   constructor() {

--- a/examples/NeuroEvolution-steering/index.html
+++ b/examples/NeuroEvolution-steering/index.html
@@ -1,8 +1,9 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates neuroevolution with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>

--- a/examples/NeuroEvolution-steering/index.html
+++ b/examples/NeuroEvolution-steering/index.html
@@ -3,7 +3,7 @@
   Learn more about the ml5.js project: https://ml5js.org/
   ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
 
-  This example demonstrates neuroevolution with ml5.neuralNetwork.
+  This example demonstrates neuroevolutionary steering with ml5.neuralNetwork.
 -->
 
 <!DOCTYPE html>
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ml5.js NeuroEvolution Steering</title>
+    <title>ml5.js neuralNetwork Neuroevolution Steering</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/NeuroEvolution-steering/index.html
+++ b/examples/NeuroEvolution-steering/index.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ml5.js NeuroEvolution Steering</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
   <body>

--- a/examples/NeuroEvolution-steering/sketch.js
+++ b/examples/NeuroEvolution-steering/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates neuroevolution with ml5.neuralNetwork.
+ */
 
 let creatures = [];
 let timeSlider;

--- a/examples/Sentiment/index.html
+++ b/examples/Sentiment/index.html
@@ -9,7 +9,7 @@
 <html>
   <head>
     <title>ml5.js Sentiment Analysis</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>
 

--- a/examples/Sentiment/index.html
+++ b/examples/Sentiment/index.html
@@ -1,13 +1,14 @@
 <!--
- Copyright (c) 2023 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates sentiment analysis with ml5.sentiment.
 -->
 
 <html>
   <head>
-    <title>ml5 - Sentiment</title>
+    <title>ml5.js Sentiment Analysis</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/Sentiment/index.html
+++ b/examples/Sentiment/index.html
@@ -8,7 +8,7 @@
 
 <html>
   <head>
-    <title>ml5.js Sentiment Analysis</title>
+    <title>ml5.js Sentiment Analysis Example</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
     <script src="../../dist/ml5.js"></script>
   </head>

--- a/examples/Sentiment/sketch.js
+++ b/examples/Sentiment/sketch.js
@@ -1,7 +1,10 @@
-// Copyright (c) 2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates sentiment analysis with ml5.sentiment.
+ */
 
 let sentiment;
 let statusEl; // to display model loading status


### PR DESCRIPTION
This PR updates the example sketches.
- update headers of the example sketches with new friendly headers
- Update p5 versions to `1.9.2`
- fix various typos and inconsistencies in the titles of the sketches

Please don't hesitate to give any suggestions about the friendly headers.