### PR TITLE
Make `flipped` an alias for `flipHorizontal`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,6 @@ yarn run build
 
 This will create a production version of the library in `/dist` directory.
 
-
 ## Unit Tests
 
 To run the unit tests, run the following command
@@ -195,6 +194,7 @@ The `moldObject` consists of key-value pairs. The key defines the name of an all
 - `type` (required): A string defining the correct type, can be `"number"`, `"enum"`, `"boolean"`, `"string"`, `"object"`, or `"undefined"`.
 - `default` (required): The default value in case the user does not provide a value or provides an erroneous value for the option.
 - `ignore` (optional): A boolean defining whether the key should be ignored. Defaults to false. Useful when set to a dynamically evaluated value (see section below).
+- `alias` (optional): A string defining an alternative name for this option.
 - Specifically for `type: "number"`:
   - `min` (optional): A number defining the minimum value.
   - `max` (optional): A number defining the maximum value.

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -136,6 +136,7 @@ class BodyPose {
         {
           flipHorizontal: {
             type: "boolean",
+            alias: "flipped",
             default: false,
           },
         },

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -127,6 +127,7 @@ class BodySegmentation {
           },
           flipHorizontal: {
             type: "boolean",
+            alias: "flipped",
             default: false,
           },
         },
@@ -171,6 +172,7 @@ class BodySegmentation {
           },
           flipHorizontal: {
             type: "boolean",
+            alias: "flipped",
             default: false,
           },
         },

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -100,6 +100,7 @@ class FaceMesh {
       {
         flipHorizontal: {
           type: "boolean",
+          alias: "flipped",
           default: false,
         },
       },

--- a/src/HandPose/index.js
+++ b/src/HandPose/index.js
@@ -102,6 +102,7 @@ class HandPose {
       {
         flipHorizontal: {
           type: "boolean",
+          alias: "flipped",
           default: false,
         },
       },

--- a/tests/unit/handleOptions.test.js
+++ b/tests/unit/handleOptions.test.js
@@ -1,26 +1,30 @@
-import handleOptions from '../../src/utils/handleOptions';
+import handleOptions from "../../src/utils/handleOptions";
 
-describe('handleOptions', () => {
-  const warnSpy = jest.spyOn(console, 'warn');
+describe("handleOptions", () => {
+  const warnSpy = jest.spyOn(console, "warn");
 
-  it('uses defaults if no values provided', () => {
-    const config = handleOptions({}, {
-      maskType: {
-        type: "enum",
-        enums: ["person", "background"],
-        default: "background",
+  it("uses defaults if no values provided", () => {
+    const config = handleOptions(
+      {},
+      {
+        maskType: {
+          type: "enum",
+          enums: ["person", "background"],
+          default: "background",
+        },
+        flipHorizontal: {
+          type: "boolean",
+          default: false,
+        },
       },
-      flipHorizontal: {
-        type: "boolean",
-        default: false
-      }
-    }, '');
-    expect(config.maskType).toBe('background');
+      ""
+    );
+    expect(config.maskType).toBe("background");
     expect(config.flipHorizontal).toBe(false);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  describe('ignoring properties depending on other values', () => {
+  describe("ignoring properties depending on other values", () => {
     const mold = {
       runtime: {
         type: "enum",
@@ -31,36 +35,54 @@ describe('handleOptions', () => {
         type: "string",
         default: "https://cdn.jsdelivr.net/npm/@mediapipe/hands",
         ignore: (config) => config.runtime !== "mediapipe",
-      }
+      },
     };
 
-    it('will use the default if applicable', () => {
-      const config = handleOptions({
-        runtime: 'mediapipe'
-      }, mold, '');
-      expect(config.solutionPath).toBe("https://cdn.jsdelivr.net/npm/@mediapipe/hands");
+    it("will use the default if applicable", () => {
+      const config = handleOptions(
+        {
+          runtime: "mediapipe",
+        },
+        mold,
+        ""
+      );
+      expect(config.solutionPath).toBe(
+        "https://cdn.jsdelivr.net/npm/@mediapipe/hands"
+      );
     });
 
-    it('will not use the default if not applicable', () => {
-      const config = handleOptions({
-        runtime: 'tfjs'
-      }, mold, '');
+    it("will not use the default if not applicable", () => {
+      const config = handleOptions(
+        {
+          runtime: "tfjs",
+        },
+        mold,
+        ""
+      );
       expect(config.solutionPath).toBeUndefined();
     });
 
-    it('will use a provided value if applicable', () => {
-      const config = handleOptions({
-        runtime: 'mediapipe',
-        solutionPath: 'https://example.com'
-      }, mold, '');
-      expect(config.solutionPath).toBe('https://example.com');
+    it("will use a provided value if applicable", () => {
+      const config = handleOptions(
+        {
+          runtime: "mediapipe",
+          solutionPath: "https://example.com",
+        },
+        mold,
+        ""
+      );
+      expect(config.solutionPath).toBe("https://example.com");
     });
 
-    it('will ignore a provided value if not applicable', () => {
-      const config = handleOptions({
-        runtime: 'tfjs',
-        solutionPath: 'https://example.com'
-      }, mold, '');
+    it("will ignore a provided value if not applicable", () => {
+      const config = handleOptions(
+        {
+          runtime: "tfjs",
+          solutionPath: "https://example.com",
+        },
+        mold,
+        ""
+      );
       expect(config.solutionPath).toBeUndefined();
       // Note: there is no warning here
     });
@@ -68,98 +90,135 @@ describe('handleOptions', () => {
 
   // helper for checking a single property value against a mold
   function checkProperty(propertyMold, providedValue, expectedReturn) {
-    const config = handleOptions({
-      key: providedValue
-    }, {
-      key: propertyMold
-    }, '');
+    const config = handleOptions(
+      {
+        key: providedValue,
+      },
+      {
+        key: propertyMold,
+      },
+      ""
+    );
     expect(config.key).toBe(expectedReturn);
   }
 
-  describe('enum handling', () => {
+  describe("enum handling", () => {
     const mold = {
       property: {
         type: "enum",
         enums: ["person", "background"],
         default: "background",
-      }
-    }
+      },
+    };
 
-    it('is case-insensitive by default', () => {
-      const config = handleOptions({ property: 'Person' }, mold, '');
-      expect(config.property).toBe('person');
+    it("is case-insensitive by default", () => {
+      const config = handleOptions({ property: "Person" }, mold, "");
+      expect(config.property).toBe("person");
     });
 
-    it('falls back to the default if given an invalid value', () => {
-      const config = handleOptions({ property: 'invalid value' }, mold, '');
-      expect(config.property).toBe('background');
+    it("falls back to the default if given an invalid value", () => {
+      const config = handleOptions({ property: "invalid value" }, mold, "");
+      expect(config.property).toBe("background");
       expect(warnSpy).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('number handling', () => {
-    describe('enforcing a minimum and maximum', () => {
+  describe("number handling", () => {
+    describe("enforcing a minimum and maximum", () => {
       const mold = {
-          type: "number",
-          min: 0,
-          max: 1,
-          default: 0.25,
-        };
+        type: "number",
+        min: 0,
+        max: 1,
+        default: 0.25,
+      };
 
-      it('accepts value in the range', () => {
+      it("accepts value in the range", () => {
         checkProperty(mold, 0.75, 0.75);
         checkProperty(mold, 0.5, 0.5);
       });
 
-      it('is inclusive of the min and max', () => {
+      it("is inclusive of the min and max", () => {
         checkProperty(mold, 0, 0);
         checkProperty(mold, 1, 1);
       });
 
-      it('uses the default if out of range', () => {
+      it("uses the default if out of range", () => {
         checkProperty(mold, -1, 0.25);
         checkProperty(mold, 2, 0.25);
         expect(warnSpy).toHaveBeenCalledTimes(2);
       });
     });
 
-    describe('enforcing an integer value', () => {
+    describe("enforcing an integer value", () => {
       const mold = {
         type: "number",
         default: 10,
-        integer: true
+        integer: true,
       };
 
-      it('allows integers', () => {
+      it("allows integers", () => {
         checkProperty(mold, 0, 0);
-        checkProperty(mold, 1.00, 1);
+        checkProperty(mold, 1.0, 1);
         checkProperty(mold, 20, 20);
       });
 
-      it('uses the default on floats', () => {
+      it("uses the default on floats", () => {
         checkProperty(mold, 0.123, 10);
         checkProperty(mold, 1.2, 10);
         expect(warnSpy).toHaveBeenCalledTimes(2);
       });
     });
 
-    describe('enforcing multiples of a value', () => {
+    describe("enforcing multiples of a value", () => {
       const mold = {
         type: "number",
         multipleOf: 32,
         default: 256,
       };
 
-      it('allows multiples', () => {
+      it("allows multiples", () => {
         checkProperty(mold, 0, 0);
         checkProperty(mold, 32, 32);
         checkProperty(mold, 64, 64);
       });
 
-      it('uses the default if not a multiple', () => {
+      it("uses the default if not a multiple", () => {
         checkProperty(mold, 10, 256);
         expect(warnSpy).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe("alias handling", () => {
+    const mold = {
+      property: {
+        type: "number",
+        default: 0,
+        alias: "aliasProperty",
+      },
+    };
+
+    it("uses the alias if provided", () => {
+      const config = handleOptions(
+        {
+          aliasProperty: 10,
+        },
+        mold,
+        ""
+      );
+      expect(config.property).toBe(10);
+    });
+
+    it("uses the original key if both original and alias are provided", () => {
+      const config = handleOptions(
+        {
+          aliasProperty: 10,
+          property: 20,
+        },
+        mold,
+        ""
+      );
+      expect(config.property).toBe(20);
     });
   });
 });


### PR DESCRIPTION
This PR adds `flipped` as an alias for `flipHorizontal`.
- Adds alias feature to `handleOptions` function. An `alias` property can now be provided to the `moldObject`, which sets an alias name for an option.
- Changes the mold objects of `handPose`, `faceMesh`, `bodyPose`, and `bodySegmentation` to include `flipped` as an alias for `flipHorizontal`.

TODO:
The `MoveNet` model does not support a `flipHorizontal` option natively. For `MoveNet`, we could try to flip the key-points in ml5 when `flipped` or `flipHorizontal` is set to `true`.