### PR TITLE
rename score to confidence across all models

### DIFF
--- a/examples/BodyPose-keypoints/sketch.js
+++ b/examples/BodyPose-keypoints/sketch.js
@@ -37,7 +37,7 @@ function draw() {
     for (let j = 0; j < pose.keypoints.length; j++) {
       let keypoint = pose.keypoints[j];
       // Only draw a circle if the keypoint's confidence is bigger than 0.1
-      if (keypoint.score > 0.1) {
+      if (keypoint.confidence > 0.1) {
         fill(0, 255, 0);
         noStroke();
         circle(keypoint.x, keypoint.y, 10);

--- a/examples/BodyPose-skeleton/sketch.js
+++ b/examples/BodyPose-skeleton/sketch.js
@@ -43,7 +43,7 @@ function draw() {
       let pointA = pose.keypoints[pointAIndex];
       let pointB = pose.keypoints[pointBIndex];
       // Only draw a line if both points are confident enough
-      if (pointA.score > 0.1 && pointB.score > 0.1) {
+      if (pointA.confidence > 0.1 && pointB.confidence > 0.1) {
         stroke(255, 0, 0);
         strokeWeight(2);
         line(pointA.x, pointA.y, pointB.x, pointB.y);
@@ -57,7 +57,7 @@ function draw() {
     for (let j = 0; j < pose.keypoints.length; j++) {
       let keypoint = pose.keypoints[j];
       // Only draw a circle if the keypoint's confidence is bigger than 0.1
-      if (keypoint.score > 0.1) {
+      if (keypoint.confidence > 0.1) {
         fill(0, 255, 0);
         noStroke();
         circle(keypoint.x, keypoint.y, 10);

--- a/examples/HandPose-parts/sketch.js
+++ b/examples/HandPose-parts/sketch.js
@@ -56,5 +56,4 @@ function draw() {
 function gotHands(results) {
   // Save the output to the hands variable
   hands = results;
-  console.log(hands);
 }

--- a/examples/Sentiment/sketch.js
+++ b/examples/Sentiment/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   inputBox = createInput("Today is the happiest day and is full of rainbows!");
   inputBox.attribute("size", "75");
   submitBtn = createButton("submit");
-  sentimentResult = createP("Sentiment score:");
+  sentimentResult = createP("Sentiment confidence:");
 
   // predicting the sentiment when submit button is pressed
   submitBtn.mousePressed(getSentiment);
@@ -36,7 +36,7 @@ function getSentiment() {
   let prediction = sentiment.predict(text);
 
   // display sentiment result on html page
-  sentimentResult.html("Sentiment score: " + prediction.score);
+  sentimentResult.html("Sentiment confidence: " + prediction.confidence);
 }
 
 // a callback function that is called when model is ready

--- a/src/HandPose/index.js
+++ b/src/HandPose/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 ml5
+// Copyright (c) 2020-2024 ml5
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -14,6 +14,7 @@ import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
 import handleOptions from "../utils/handleOptions";
 import { mediaReady } from "../utils/imageUtilities";
+import objectRenameKey from "../utils/objectRenameKey";
 
 class HandPose {
   /**
@@ -142,8 +143,11 @@ class HandPose {
       image,
       this.runtimeConfig
     );
+    // Modify the prediction result to make it more user-friendly
     let result = predictions;
-    result = this.addKeypoints(result);
+    this.renameScoreToConfidence(result);
+    this.addKeypoints(result);
+
     if (typeof callback === "function") callback(result);
     return result;
   }
@@ -201,13 +205,26 @@ class HandPose {
         this.runtimeConfig
       );
       let result = predictions;
-      result = this.addKeypoints(result);
+      // Modify the prediction result to make it more user-friendly
+      this.renameScoreToConfidence(result);
+      this.addKeypoints(result);
+
       this.detectCallback(result);
       // wait for the frame to update
       await tf.nextFrame();
     }
     this.detecting = false;
     this.signalStop = false;
+  }
+
+  /**
+   * Renames the score key to confidence in the detection results.
+   * @param {Object[]} hands - The detection results.
+   */
+  renameScoreToConfidence(hands) {
+    hands.forEach((hand) => {
+      objectRenameKey(hand, "score", "confidence");
+    });
   }
 
   /**

--- a/src/Sentiment/index.js
+++ b/src/Sentiment/index.js
@@ -97,7 +97,7 @@ class Sentiment {
   /**
    * Scores the sentiment of given text with a value between 0 ("negative") and 1 ("positive").
    * @param {String} text - string of text to predict.
-   * @returns {{score: Number}}
+   * @returns {{confidence: Number}}
    */
   predict(text) {
     // Convert to lower case and remove all punctuations.
@@ -120,12 +120,12 @@ class Sentiment {
     const paddedSequence = padSequences([sequence], this.maxLen);
     const input = tf.tensor2d(paddedSequence, [1, this.maxLen]);
     const predictOut = this.model.predict(input);
-    const score = predictOut.dataSync()[0];
+    const confidence = predictOut.dataSync()[0];
     predictOut.dispose();
     input.dispose();
 
     return {
-      score,
+      confidence,
     };
   }
 }

--- a/src/utils/objectRenameKey.js
+++ b/src/utils/objectRenameKey.js
@@ -1,0 +1,13 @@
+/**
+ * Renames a key in an object
+ *
+ * @param {Object} obj - The object to modify
+ * @param {string} oldKey - The key to rename
+ * @param {string} newKey - The new key name
+ * @returns the modified object
+ */
+export default function objectRenameKey(obj, oldKey, newKey) {
+  Object.assign(obj, { [newKey]: obj[oldKey] });
+  delete obj[oldKey];
+  return obj;
+}


### PR DESCRIPTION
- adds utility function for renaming a key in an object
- rename the key "score" to "confidence" in the prediction output of `bodyPose`, `handPose`, and `sentiment`
  - `faceMesh` and `bodySegmentation` does not have a score/confidence property
  - `neuralNetwork` and `imageClassifier` already use "confidence" as the key
