### PR TITLE
P5 upload script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+P5_USERNAME=ml5
+P5_PASSWORD=********

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,26 @@ npm publish --tag alpha --access public
    https://unpkg.com/ml5@[version]/dist/ml5.js
 ```
 
+## Update p5 Web Editor Sketches
+
+To update the p5 Web Editor sketches, first create a `.env` file with the following content:
+
+```
+  P5_USERNAME=<p5 web editor username here>
+  P5_PASSWORD=<p5 web editor password here>
+
+```
+
+Then, run the following command:
+
+```
+yarn run upload-examples
+```
+
+This script will delete all existing sketches on the web editor and upload all example sketches in the `examples/` directory.
+
+Currently, this script cannot upload non-text files. Those files will be listed in the console and will require manual uploading.
+
 ## All Contributors
 
 If you contributed to the project in any way, we would like to include you in our [contributors list in README.md](https://github.com/ml5js/ml5-next-gen?tab=readme-ov-file#contributors).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,11 @@ Then, run the following command:
 yarn run upload-examples
 ```
 
-This script will delete all existing sketches on the web editor and upload all example sketches in the `examples/` directory.
+The script will match the directory name of a local example sketch with the name of the sketch on the web editor. If a local directory name is the same as a sketch name on the web editor (case sensitive), the content of the sketch will be updated (with the sharing URL unchanged). If a local directory name is not found on the web editor, a new web editor sketch will be created. If a web editor sketch does not have a matching local directory name, the script will not automatically delete the web editor sketch. Any deletion have to be done manually on the web editor.
 
-Currently, this script cannot upload non-text files. Those files will be listed in the console and will require manual uploading.
+Updating an existing sketch will not affect the collections on the p5 web editor. Newly uploaded sketches will not be automatically added to any collections.
+
+Currently, this script cannot upload non-text files. Those files that have not been uploaded will be listed and will require manual uploading.
 
 ## All Contributors
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "webpack serve --config webpack.config.js --mode development",
     "format": "prettier --write \"**/*.js\"",
     "postinstall": "patch-package",
-    "test": "jest --config tests/jest.config.js"
+    "test": "jest --config tests/jest.config.js",
+    "upload-examples": "node scripts/uploadExamples.js"
   },
   "files": [
     "dist"
@@ -33,7 +34,9 @@
     "@tensorflow/tfjs-node": "^4.17.0",
     "all-contributors-cli": "^6.26.1",
     "babel-jest": "^29.7.0",
+    "bson-objectid": "^2.0.4",
     "cross-fetch": "^4.0.0",
+    "dotenv": "^16.4.5",
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -67,6 +70,5 @@
       "@babel/preset-env"
     ]
   },
-  "prettier": {
-  }
+  "prettier": {}
 }

--- a/scripts/uploadExamples.js
+++ b/scripts/uploadExamples.js
@@ -2,10 +2,16 @@ const fs = require("fs");
 const dotenv = require("dotenv");
 const objectID = require("bson-objectid");
 const ml5Version = require("../package.json").version;
-let sessionID = "";
+
 dotenv.config();
 
 const P5_URL = "https://editor.p5js.org";
+const TEXT_FILE_REGEX =
+  /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|jsx|xml|stl|mtl)$/i;
+
+let sessionID = "";
+const manualUploadList = [];
+let manualUploadFlag = false;
 
 /**
  * Get the session ID for the p5 web editor.
@@ -56,13 +62,24 @@ async function uploadSketch(sketch) {
     },
     body: JSON.stringify(sketch),
   });
-  const data = await res.json();
+  if (res.status != 200) {
+    console.log("🔴Failed to upload sketch: " + sketch.name);
+  } else {
+    if (manualUploadFlag) {
+      console.log("🟡Manual upload of non-text file required: " + sketch.name);
+      manualUploadFlag = false;
+      console.log(manualUploadList);
+    }
+    console.log("🟢Successfully uploaded sketch: " + sketch.name);
+  }
 }
 
 /**
  * Upload a binary file to the p5 web editor.
  * @param {string} filePath - The file path.
  * @returns
+ *
+ * @todo: This function does not work, non-text files need to be uploaded manually for now
  */
 async function uploadFile(filePath) {
   const file = fs.readFileSync(filePath);
@@ -81,18 +98,60 @@ async function uploadFile(filePath) {
   //return data;
 }
 
+getExistingFiles = async () => {
+  const res = await fetch(
+    P5_URL + `/editor/${process.env.P5_USERNAME}/projects`,
+    {
+      method: "GET",
+      headers: {
+        Cookie: `sessionId=${sessionID}`,
+      },
+    }
+  );
+  if (!(res.status == 200 || res.status == 304)) {
+    throw new Error(
+      "Failed to get existing files. p5 Server returned status code: " +
+        res.status
+    );
+  }
+  return await res.json();
+};
+
+deleteFile = async (file) => {
+  const res = await fetch(P5_URL + `/editor/projects/${file.id}`, {
+    method: "DELETE",
+    headers: {
+      Cookie: `sessionId=${sessionID}`,
+    },
+  });
+  if (res.status != 200) {
+    console.log("🔴Failed to delete file: " + file.name);
+  } else {
+    console.log("🟢Successfully deleted file: " + file.name);
+  }
+};
+
 /**
  * Get the file path of each item in a given directory.
  *
  * @param {string} dir - The directory path.
  * @returns - An array of file paths.
  */
-function getFilepathList(dir) {
+function getFilepaths(dir) {
   let files = [];
   fs.readdirSync(dir).forEach((file) => {
     files.push(`${dir}/${file}`);
   });
   return files;
+}
+
+/**
+ * Check if a file is a text file.
+ * @param {string} filename
+ * @returns {boolean} True if the file is a text file, false otherwise.
+ */
+function isTextFile(filename) {
+  return TEXT_FILE_REGEX.test(filename);
 }
 
 /**
@@ -103,16 +162,19 @@ function getFilepathList(dir) {
  * @returns {Object} The file object.
  */
 function createFileObject(fileID, filePath) {
-  const fileName = filePath.split("/").pop();
-  const fileExtension = fileName.split(".").pop();
+  const filename = filePath.split("/").pop();
   let fileContent = "";
-  if (fileExtension === "bin") {
-  } else {
+  if (isTextFile(filename)) {
     fileContent = fs.readFileSync(filePath, "utf8");
+    fileContent = replaceWithCdnURL(fileContent);
+  } else {
+    //TODO: handle upload non-text files
+    manualUploadList.push(filePath);
+    manualUploadFlag = true;
+    return null;
   }
-  fileContent = replaceWithCdnURL(fileContent);
   return {
-    name: fileName,
+    name: filename,
     id: fileID,
     _id: fileID,
     fileType: "file",
@@ -151,23 +213,27 @@ function replaceWithCdnURL(content) {
 }
 
 /**
- * Recursively add files to the sketch object.
- * @param {*} folderPath - The folder path.
- * @param {*} fileArray - The array storing file objects in the sketch.
- * @param {*} childrenArray - The array storing the children of the folder.
+ * Recursively add files and folders to the sketch object.
+ * @param {*} currentPath - The current directory path
+ * @param {*} fileArray - The array storing file and folder objects in the sketch.
+ * @param {*} childrenArray - The array storing the children ids of the folder.
  */
-async function recursiveAddFiles(folderPath, fileArray, childrenArray) {
-  const files = getFilepathList(folderPath);
-  files.forEach((filePath) => {
+async function recursiveAddFiles(currentPath, fileArray, childrenArray) {
+  const filepaths = getFilepaths(currentPath);
+  filepaths.forEach((filePath) => {
     const fileID = objectID().toString();
     if (fs.lstatSync(filePath).isDirectory()) {
       const folder = createFolderObject(fileID, filePath);
       fileArray.push(folder);
+      childrenArray.push(fileID);
       recursiveAddFiles(filePath, fileArray, folder.children);
     } else {
-      fileArray.push(createFileObject(fileID, filePath));
+      const fileObject = createFileObject(fileID, filePath);
+      if (fileObject) {
+        fileArray.push(fileObject);
+        childrenArray.push(fileID);
+      }
     }
-    childrenArray.push(fileID);
   });
 }
 
@@ -186,19 +252,33 @@ function createSketchObject(sketchDirPath) {
 
   recursiveAddFiles(sketchDirPath, sketch.files, sketch.files[0].children);
 
+  // Set the sketch.js file as the default selected file.
+  for (const file of sketch.files) {
+    if (file.name == "sketch.js") {
+      file.isSelectedFile = true;
+      break;
+    }
+  }
+
   return sketch;
 }
 
 /**
- * This script uploads the examples to the server.
+ * Entry point of the script.
+ * This script uploads each sketch in the examples to the server.
  */
 async function main() {
   sessionID = await getP5SessionID();
-  const sketchPaths = getFilepathList("examples");
+  const sketchPaths = getFilepaths("examples");
+  const oldFiles = await getExistingFiles();
+  for (const file of oldFiles) {
+    await deleteFile(file);
+  }
 
-  const sketchObject = createSketchObject(sketchPaths[17]);
-  console.log(sketchObject);
-  await uploadSketch(sketchObject);
+  for (const sketchPath of sketchPaths) {
+    const sketchObject = createSketchObject(sketchPath);
+    await uploadSketch(sketchObject);
+  }
 }
 
 main();

--- a/scripts/uploadExamples.js
+++ b/scripts/uploadExamples.js
@@ -1,0 +1,204 @@
+const fs = require("fs");
+const dotenv = require("dotenv");
+const objectID = require("bson-objectid");
+const ml5Version = require("../package.json").version;
+let sessionID = "";
+dotenv.config();
+
+const P5_URL = "https://editor.p5js.org";
+
+/**
+ * Get the session ID for the p5 web editor.
+ *
+ * @returns {String} The session ID.
+ */
+async function getP5SessionID() {
+  // The credentials for p5 web editor.
+  const credentials = {
+    email: process.env.P5_USERNAME,
+    password: process.env.P5_PASSWORD,
+  };
+
+  const res = await fetch(P5_URL + "/editor/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  // Check if the credentials are valid.
+  if (res.status == 401) {
+    throw new Error(
+      "Invalid credentials. Please maake sure the username and password are set correctly in the .env file."
+    );
+  } else if (res.status != 200) {
+    throw new Error(
+      "Failed to login to p5 web editor. p5 Server returned status code: " +
+        res.status
+    );
+  }
+  let sid = res.headers.get("set-cookie").split(";")[0].split("=")[1];
+  return sid;
+}
+
+/**
+ * upload a sketch on the p5 web editor.
+ *
+ * @param {Object} sketch - The sketch object.
+ */
+async function uploadSketch(sketch) {
+  const res = await fetch(P5_URL + "/editor/projects", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `sessionId=${sessionID}`,
+    },
+    body: JSON.stringify(sketch),
+  });
+  const data = await res.json();
+}
+
+/**
+ * Upload a binary file to the p5 web editor.
+ * @param {string} filePath - The file path.
+ * @returns
+ */
+async function uploadFile(filePath) {
+  const file = fs.readFileSync(filePath);
+  const res = await fetch(P5_URL + "/editor/S3/sign", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/octect-stream",
+      Cookie: `sessionId=${sessionID}`,
+    },
+    body: file,
+  });
+  const data = await res.text();
+  console.log(data);
+  //const data = await res.json();
+  //console.log(data);
+  //return data;
+}
+
+/**
+ * Get the file path of each item in a given directory.
+ *
+ * @param {string} dir - The directory path.
+ * @returns - An array of file paths.
+ */
+function getFilepathList(dir) {
+  let files = [];
+  fs.readdirSync(dir).forEach((file) => {
+    files.push(`${dir}/${file}`);
+  });
+  return files;
+}
+
+/**
+ * Create a p5 file object from a file path.
+ *
+ * @param {string} fileID - The file ID.
+ * @param {string} filePath - The file path.
+ * @returns {Object} The file object.
+ */
+function createFileObject(fileID, filePath) {
+  const fileName = filePath.split("/").pop();
+  const fileExtension = fileName.split(".").pop();
+  let fileContent = "";
+  if (fileExtension === "bin") {
+  } else {
+    fileContent = fs.readFileSync(filePath, "utf8");
+  }
+  fileContent = replaceWithCdnURL(fileContent);
+  return {
+    name: fileName,
+    id: fileID,
+    _id: fileID,
+    fileType: "file",
+    content: fileContent,
+  };
+}
+
+/**
+ * Create a p5 folder object.
+ * @param {s} folderID - The folder ID.
+ * @param {string} folderPath - The folder path. If not provided, the folder will be root.
+ * @returns {Object} The folder object.
+ */
+function createFolderObject(folderID, folderPath) {
+  const folderName = folderPath ? folderPath.split("/").pop() : "root";
+  return {
+    name: folderName,
+    id: folderID,
+    _id: folderID,
+    fileType: "folder",
+    children: [],
+    content: "",
+  };
+}
+
+/**
+ * Replace the local file path with the ml5.js CDN URL.
+ * @param {string} content - The content of the file.
+ * @returns {string} The content with the CDN URL.
+ */
+function replaceWithCdnURL(content) {
+  return content.replace(
+    "../../dist/ml5.js",
+    `https://unpkg.com/ml5@${ml5Version}/dist/ml5.min.js`
+  );
+}
+
+/**
+ * Recursively add files to the sketch object.
+ * @param {*} folderPath - The folder path.
+ * @param {*} fileArray - The array storing file objects in the sketch.
+ * @param {*} childrenArray - The array storing the children of the folder.
+ */
+async function recursiveAddFiles(folderPath, fileArray, childrenArray) {
+  const files = getFilepathList(folderPath);
+  files.forEach((filePath) => {
+    const fileID = objectID().toString();
+    if (fs.lstatSync(filePath).isDirectory()) {
+      const folder = createFolderObject(fileID, filePath);
+      fileArray.push(folder);
+      recursiveAddFiles(filePath, fileArray, folder.children);
+    } else {
+      fileArray.push(createFileObject(fileID, filePath));
+    }
+    childrenArray.push(fileID);
+  });
+}
+
+/**
+ * Create a p5 sketch object from a given sketch path.
+ * @param {*} sketchDirPath
+ * @returns {Object} The sketch object.
+ */
+function createSketchObject(sketchDirPath) {
+  const rootID = objectID().toString();
+  const sketchName = sketchDirPath.split("/").pop();
+  const sketch = {
+    name: sketchName,
+    files: [createFolderObject(rootID)],
+  };
+
+  recursiveAddFiles(sketchDirPath, sketch.files, sketch.files[0].children);
+
+  return sketch;
+}
+
+/**
+ * This script uploads the examples to the server.
+ */
+async function main() {
+  sessionID = await getP5SessionID();
+  const sketchPaths = getFilepathList("examples");
+
+  const sketchObject = createSketchObject(sketchPaths[17]);
+  console.log(sketchObject);
+  await uploadSketch(sketchObject);
+}
+
+main();

--- a/scripts/uploadExamples.js
+++ b/scripts/uploadExamples.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const dotenv = require("dotenv");
 const objectID = require("bson-objectid");
+const readline = require("node:readline/promises");
+const { stdin: input, stdout: output } = require("node:process");
 const ml5Version = require("../package.json").version;
 
 dotenv.config();
@@ -253,6 +255,20 @@ function createSketchObject(sketchDirPath) {
  * This script uploads each sketch in the examples to the server.
  */
 async function main() {
+  // Confirm that the user wants to upload the examples.
+  const rl = readline.createInterface({ input, output });
+  const response = await rl.question(
+    "This script will delete all existing sketches on the p5 web editor and upload the local examples. Please enter 'confirm' to proceed: "
+  );
+  if (response != "confirm") {
+    rl.close();
+    console.log("The upload was cancelled.");
+    process.exit(0);
+  } else {
+    console.log("Proceeding with the deletion and upload...");
+    rl.close();
+  }
+
   // Get the session ID.
   console.log("Obtaining session ID...");
   const sessionRes = await getP5SessionID();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,6 +2137,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+bson-objectid@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-2.0.4.tgz#339211572ef97dc98f2d68eaee7b99b7be59a089"
+  integrity sha512-vgnKAUzcDoa+AeyYwXCoHyF2q6u/8H46dxu5JN+4/TZeq/Dlinn0K6GvxsCLb3LHUJl0m/TLiEK31kUwtgocMQ==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -2824,6 +2829,11 @@ dot-case@^3.0.4:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR adds a script that uploads the example sketches to the p5 web editor. It uses the same API endpoints as the browser p5 web editor.

Currently, this script can only upload text files. It will log the non-text files in the console, which will require manual uploading. I will look into uploading non-text files in the future, but it is not as straightforward as uploading text files.