### PR TITLE
update sentiment

### DIFF
--- a/examples/Sentiment/sketch.js
+++ b/examples/Sentiment/sketch.js
@@ -33,15 +33,17 @@ function getSentiment() {
   let text = inputBox.value();
 
   // make the prediction
-  let prediction = sentiment.predict(text);
-
-  // display sentiment result on html page
-  sentimentResult.html("Sentiment confidence: " + prediction.confidence);
+  sentiment.predict(text, gotResult);
 }
 
 // a callback function that is called when model is ready
 function modelReady() {
   statusEl.html("Model loaded");
+}
+
+function gotResult(prediction) {
+  // display sentiment result on html page
+  sentimentResult.html("Sentiment confidence: " + prediction.confidence);
 }
 
 // predicting the sentiment when 'Enter' key is pressed

--- a/src/Sentiment/index.js
+++ b/src/Sentiment/index.js
@@ -132,13 +132,8 @@ class Sentiment {
     predictOut.dispose();
     input.dispose();
 
-    if (gotResult) {
-      gotResult({ confidence });
-    }
-    callback({ confidence });
-    return {
-      confidence,
-    };
+    if (callback) callback({ confidence });
+    return { confidence };
   }
 }
 

--- a/src/Sentiment/index.js
+++ b/src/Sentiment/index.js
@@ -1,6 +1,7 @@
 import * as tf from "@tensorflow/tfjs";
 import callCallback from "../utils/callcallback";
 import modelLoader from "../utils/modelLoader";
+import handleArguments from "../utils/handleArguments";
 
 /**
  * Initializes the Sentiment demo.
@@ -63,14 +64,13 @@ class Sentiment {
    */
 
   async loadModel(modelName) {
+    await tf.ready();
     const modelUrl =
       modelName.toLowerCase() === "moviereviews"
         ? "https://storage.googleapis.com/tfjs-models/tfjs/sentiment_cnn_v1/"
         : modelName;
 
     const loader = modelLoader(modelUrl, "model");
-
-    await tf.setBackend("webgl");
 
     // load in parallel
     const [model, sentimentMetadata] = await Promise.all([
@@ -96,12 +96,19 @@ class Sentiment {
 
   /**
    * Scores the sentiment of given text with a value between 0 ("negative") and 1 ("positive").
-   * @param {String} text - string of text to predict.
-   * @returns {{confidence: Number}}
+   * @param {string} text - string of text to predict.
+   * @param {function} callback - Optional. A callback function that is called once the prediction is done.
+   * @returns {{confidence: number}}
    */
-  predict(text) {
+  async predict(...inputs) {
+    const argumentObject = handleArguments(...inputs);
+    const { string, callback } = argumentObject;
+    argumentObject.require(
+      "string",
+      "A string argument is required for sentiment.predict function."
+    );
     // Convert to lower case and remove all punctuations.
-    const inputText = text
+    const inputText = string
       .trim()
       .toLowerCase()
       .replace(/[.,?!]/g, "")
@@ -120,10 +127,15 @@ class Sentiment {
     const paddedSequence = padSequences([sequence], this.maxLen);
     const input = tf.tensor2d(paddedSequence, [1, this.maxLen]);
     const predictOut = this.model.predict(input);
-    const confidence = predictOut.dataSync()[0];
+    const predictData = await predictOut.data();
+    const confidence = predictData[0];
     predictOut.dispose();
     input.dispose();
 
+    if (gotResult) {
+      gotResult({ confidence });
+    }
+    callback({ confidence });
     return {
       confidence,
     };


### PR DESCRIPTION
This PR updates sentiment with the current API standard.
- add support for `webgpu` backend, changing `Sentiment.predict` to an async method
- implement argument-handling for `predict` method
  - add a callback argument to `predict` method
  - add a warning if predict is called without a text argument
  - allow arguments to be passed in arbitrary order
- update the example sketch in accordance with the above changes