### PR TITLE
BodySegmentation: Add raw values of the detected body parts to result

### DIFF
--- a/examples/bodySegmentation-mask-background/sketch.js
+++ b/examples/bodySegmentation-mask-background/sketch.js
@@ -6,7 +6,7 @@
  * This example demonstrates separating people from the background with ml5.bodySegmentation.
  */
 
-let bodyPix;
+let bodySegmentation;
 let video;
 let segmentation;
 
@@ -15,7 +15,7 @@ let options = {
 };
 
 function preload() {
-  bodyPix = ml5.bodySegmentation("SelfieSegmentation", options);
+  bodySegmentation = ml5.bodySegmentation("SelfieSegmentation", options);
 }
 
 function setup() {
@@ -25,17 +25,18 @@ function setup() {
   video.size(width, height);
   video.hide();
 
-  bodyPix.detectStart(video, gotResults);
+  bodySegmentation.detectStart(video, gotResults);
 }
 
 function draw() {
   background(0, 0, 255);
   if (segmentation) {
-    video.mask(segmentation);
+    video.mask(segmentation.mask);
     image(video, 0, 0);
   }
 }
+
 // callback function for body segmentation
 function gotResults(result) {
-  segmentation = result.mask;
+  segmentation = result;
 }

--- a/examples/bodySegmentation-mask-body-parts/sketch.js
+++ b/examples/bodySegmentation-mask-body-parts/sketch.js
@@ -6,7 +6,7 @@
  * This example demonstrates segmenting a person by body parts with ml5.bodySegmentation.
  */
 
-let bodyPix;
+let bodySegmentation;
 let video;
 let segmentation;
 
@@ -15,7 +15,7 @@ let options = {
 };
 
 function preload() {
-  bodyPix = ml5.bodySegmentation("BodyPix", options);
+  bodySegmentation = ml5.bodySegmentation("BodyPix", options);
 }
 
 function setup() {
@@ -25,17 +25,18 @@ function setup() {
   video.size(width, height);
   video.hide();
 
-  bodyPix.detectStart(video, gotResults);
+  bodySegmentation.detectStart(video, gotResults);
 }
 
 function draw() {
   background(255);
   image(video, 0, 0);
   if (segmentation) {
-    image(segmentation, 0, 0, width, height);
+    image(segmentation.mask, 0, 0, width, height);
   }
 }
+
 // callback function for body segmentation
 function gotResults(result) {
-  segmentation = result.mask;
+  segmentation = result;
 }

--- a/examples/bodySegmentation-mask-person/sketch.js
+++ b/examples/bodySegmentation-mask-person/sketch.js
@@ -6,7 +6,7 @@
  * This example demonstrates segmenting the background from a person with ml5.bodySegmentation.
  */
 
-let bodyPix;
+let bodySegmentation;
 let video;
 let segmentation;
 
@@ -15,7 +15,7 @@ let options = {
 };
 
 function preload() {
-  bodyPix = ml5.bodySegmentation("SelfieSegmentation", options);
+  bodySegmentation = ml5.bodySegmentation("SelfieSegmentation", options);
 }
 
 function setup() {
@@ -25,18 +25,19 @@ function setup() {
   video.size(width, height);
   video.hide();
 
-  bodyPix.detectStart(video, gotResults);
+  bodySegmentation.detectStart(video, gotResults);
 }
 
 function draw() {
   background(0, 255, 0);
 
   if (segmentation) {
-    video.mask(segmentation);
+    video.mask(segmentation.mask);
     image(video, 0, 0);
   }
 }
+
 // callback function for body segmentation
 function gotResults(result) {
-  segmentation = result.mask;
+  segmentation = result;
 }

--- a/examples/bodySegmentation-select-bodypart/index.html
+++ b/examples/bodySegmentation-select-bodypart/index.html
@@ -1,0 +1,22 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates segmenting a person by body parts with ml5.bodySegmentation.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ml5.js bodySegmentation Parts Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/bodySegmentation-select-bodypart/sketch.js
+++ b/examples/bodySegmentation-select-bodypart/sketch.js
@@ -1,0 +1,51 @@
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates segmenting a person by body parts with ml5.bodySegmentation.
+ */
+
+let bodySegmentation;
+let video;
+let segmentation;
+
+let options = {
+  maskType: "parts",
+};
+
+function preload() {
+  bodySegmentation = ml5.bodySegmentation("BodyPix", options);
+}
+
+function setup() {
+  createCanvas(640, 480);
+  // Create the video
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  video.hide();
+
+  bodySegmentation.detectStart(video, gotResults);
+}
+
+function draw() {
+  background(255);
+  image(video, 0, 0);
+  if (segmentation) {
+    let gridSize = 10;
+    for (let x=0; x < video.width; x += gridSize) {
+      for (let y=0; y < video.height; y += gridSize) {
+        if (segmentation.data[y * video.width + x] == bodySegmentation.TORSO_FRONT) {
+          fill(255, 0, 0);
+          noStroke();
+          circle(x, y, gridSize);
+        }
+      }
+    }
+  }
+}
+
+// callback function for body segmentation
+function gotResults(result) {
+  segmentation = result;
+}

--- a/src/BodySegmentation/BODYPIX_PALETTE.js
+++ b/src/BodySegmentation/BODYPIX_PALETTE.js
@@ -1,97 +1,97 @@
 export default {
-  leftFace: {
+  LEFT_FACE: {
     id: 0,
     color: [110, 64, 170],
   },
-  rightFace: {
+  RIGHT_FACE: {
     id: 1,
     color: [143, 61, 178],
   },
-  leftUpperArmFront: {
+  LEFT_UPPER_ARM_FRONT: {
     id: 2,
     color: [178, 60, 178],
   },
-  leftUpperArmBack: {
+  LEFT_UPPER_ARM_BACK: {
     id: 3,
     color: [210, 62, 167],
   },
-  rightUpperArmFront: {
+  RIGHT_UPPER_ARM_FRONT: {
     id: 4,
     color: [238, 67, 149],
   },
-  rightUpperArmBack: {
+  RIGHT_UPPER_ARM_BACK: {
     id: 5,
     color: [255, 78, 125],
   },
-  leftLowerArmFront: {
+  LEFT_LOWER_ARM_FRONT: {
     id: 6,
     color: [255, 94, 99],
   },
-  leftLowerArmBack: {
+  LEFT_LOWER_ARM_BACK: {
     id: 7,
     color: [255, 115, 75],
   },
-  rightLowerArmFront: {
+  RIGHT_LOWER_ARM_FRONT: {
     id: 8,
     color: [255, 140, 56],
   },
-  rightLowerArmBack: {
+  RIGHT_LOWER_ARM_BACK: {
     id: 9,
     color: [239, 167, 47],
   },
-  leftHand: {
+  LEFT_HAND: {
     id: 10,
     color: [217, 194, 49],
   },
-  rightHand: {
+  RIGHT_HAND: {
     id: 11,
     color: [194, 219, 64],
   },
-  torsoFront: {
+  TORSO_FRONT: {
     id: 12,
     color: [175, 240, 91],
   },
-  torsoBack: {
+  TORSO_BACK: {
     id: 13,
     color: [135, 245, 87],
   },
-  leftUpperLegFront: {
+  LEFT_UPPER_LEG_FRONT: {
     id: 14,
     color: [96, 247, 96],
   },
-  leftUpperLegBack: {
+  LEFT_UPPER_LEG_BACK: {
     id: 15,
     color: [64, 243, 115],
   },
-  rightUpperLegFront: {
+  RIGHT_UPPER_LEG_FRONT: {
     id: 16,
     color: [40, 234, 141],
   },
-  rightUpperLegBack: {
+  RIGHT_UPPER_LEG_BACK: {
     id: 17,
     color: [28, 219, 169],
   },
-  leftLowerLegFront: {
+  LEFT_LOWER_LEG_FRONT: {
     id: 18,
     color: [26, 199, 194],
   },
-  leftLowerLegBack: {
+  LEFT_LOWER_LEG_BACK: {
     id: 19,
     color: [33, 176, 213],
   },
-  rightLowerLegFront: {
+  RIGHT_LOWER_LEG_FRONT: {
     id: 20,
     color: [47, 150, 224],
   },
-  rightLowerLegBack: {
+  RIGHT_LOWER_LEG_BACK: {
     id: 21,
     color: [65, 125, 224],
   },
-  leftFoot: {
+  LEFT_FOOT: {
     id: 22,
     color: [84, 101, 214],
   },
-  rightFoot: {
+  RIGHT_FOOT: {
     id: 23,
     color: [99, 81, 195],
   },

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -12,7 +12,6 @@ import * as tf from "@tensorflow/tfjs";
 import * as tfBodySegmentation from "@tensorflow-models/body-segmentation";
 import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
-import BODYPIX_PALETTE from "./BODYPIX_PALETTE";
 import { mediaReady } from "../utils/imageUtilities";
 import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
@@ -242,7 +241,6 @@ class BodySegmentation {
           tfBodySegmentation.bodyPixMaskValueToRainbowColor,
           { r: 255, g: 255, b: 255, a: 255 }
         );
-        result.bodyParts = BODYPIX_PALETTE;
     }
     result.mask = this.generateP5Image(result.maskImageData);
 
@@ -338,7 +336,6 @@ class BodySegmentation {
             tfBodySegmentation.bodyPixMaskValueToRainbowColor,
             { r: 255, g: 255, b: 255, a: 255 }
           );
-          result.bodyParts = BODYPIX_PALETTE;
       }
       result.mask = this.generateP5Image(result.maskImageData);
 

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -207,6 +207,22 @@ class BodySegmentation {
     );
 
     const result = {};
+
+    // add array of raw values to output
+    if (segmentation.length) {
+      result.imageData = await segmentation[0].mask.toImageData();
+      let data = new Array(result.imageData.width * result.imageData.height);
+      for (let i=0; i < data.length; i++) {
+        data[i] = result.imageData.data[i*4];
+      }
+      result.data = data;
+    } else {
+      result.data = [];
+      result.imageData = null;
+    }
+    // Note: our output doesn't handle BodyPix' multi-segmentation mode
+    // (which defaults to false) - this only looks at the first segmentation
+
     switch (this.runtimeConfig.maskType) {
       case "background":
         result.maskImageData = await tfBodySegmentation.toBinaryMask(
@@ -287,6 +303,22 @@ class BodySegmentation {
       );
 
       const result = {};
+
+      // add array of raw values to output
+      if (segmentation.length) {
+        result.imageData = await segmentation[0].mask.toImageData();
+        let data = new Array(result.imageData.width * result.imageData.height);
+        for (let i=0; i < data.length; i++) {
+          data[i] = result.imageData.data[i*4];
+        }
+        result.data = data;
+      } else {
+        result.data = [];
+        result.imageData = null;
+      }
+      // Note: our output doesn't handle BodyPix' multi-segmentation mode
+      // (which defaults to false) - this only looks at the first segmentation
+
       switch (this.runtimeConfig.maskType) {
         case "background":
           result.maskImageData = await tfBodySegmentation.toBinaryMask(

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -12,6 +12,7 @@ import * as tf from "@tensorflow/tfjs";
 import * as tfBodySegmentation from "@tensorflow-models/body-segmentation";
 import callCallback from "../utils/callcallback";
 import handleArguments from "../utils/handleArguments";
+import BODYPIX_PALETTE from "./BODYPIX_PALETTE";
 import { mediaReady } from "../utils/imageUtilities";
 import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
@@ -130,6 +131,12 @@ class BodySegmentation {
         },
         "bodySegmentation"
       );
+
+      // add body part constants to the instance variable
+      for (let key in BODYPIX_PALETTE) {
+        this[key] = BODYPIX_PALETTE[key].id;
+      }
+
     } else {
       pipeline = tfBodySegmentation.SupportedModels.MediaPipeSelfieSegmentation;
       modelConfig = handleOptions(
@@ -175,6 +182,11 @@ class BodySegmentation {
         },
         "bodySegmentation"
       );
+
+      // add constants to the instance variable
+      this.BACKGROUND = 0;
+      this.BODY = 255;
+
     }
 
     await tf.ready();


### PR DESCRIPTION
@MOQN brought this up during our meeting today: He ~suggested~ requested to have some way of accessing the raw values (detected class ids per pixel) - so that so that the users of the library don't have to derive those from the color values of the (multi-colored) mask.

I sketched out two options here - but I'd think we should only pick one (or none) of them:

* `.values`: an array of numbers, one per pixel of the input image
* `.valuesImageData`: the image data as the the tf model is returning it (this has the value stored in the red channel, so one would want to look at only every fourth entry in the array)

Open questions:
- Do we need to handle the case where segmentation.length is zero?

@shiffman @ziyuan-linn @MOQN 🙏