### PR TITLE
switch default runtime to `tfjs`

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -93,7 +93,7 @@ class BodyPose {
           runtime: {
             type: "enum",
             enums: ["mediapipe", "tfjs"],
-            default: "mediapipe",
+            default: "tfjs",
           },
           enableSmoothing: {
             type: "boolean",

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -141,7 +141,7 @@ class BodySegmentation {
           runtime: {
             type: "enum",
             enums: ["mediapipe, tfjs"],
-            default: "mediapipe",
+            default: "tfjs",
           },
           modelType: {
             type: "enum",

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -65,7 +65,7 @@ class FaceMesh {
         runtime: {
           type: "enum",
           enums: ["mediapipe", "tfjs"],
-          default: "mediapipe",
+          default: "tfjs",
         },
         maxFaces: {
           type: "number",

--- a/src/HandPose/index.js
+++ b/src/HandPose/index.js
@@ -73,7 +73,7 @@ class HandPose {
         runtime: {
           type: "enum",
           enums: ["mediapipe", "tfjs"],
-          default: "mediapipe",
+          default: "tfjs",
         },
         modelType: {
           type: "enum",


### PR DESCRIPTION
This PR changes the default runtime of `handPose`, `bodySegmentation`, `faceMesh`, and `bodyPose` to `tfjs` as discussed in #134.