### PR TITLE
change p5 video resolution in examples

### DIFF
--- a/examples/bodyPose-blazePose-keypoints/sketch.js
+++ b/examples/bodyPose-blazePose-keypoints/sketch.js
@@ -20,7 +20,7 @@ function setup() {
 
   // Create the video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Start detecting poses in the webcam video

--- a/examples/bodyPose-blazePose-skeleton/sketch.js
+++ b/examples/bodyPose-blazePose-skeleton/sketch.js
@@ -21,7 +21,7 @@ function setup() {
 
   // Create the video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Start detecting poses in the webcam video

--- a/examples/bodyPose-keypoints/sketch.js
+++ b/examples/bodyPose-keypoints/sketch.js
@@ -20,7 +20,7 @@ function setup() {
 
   // Create the video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Start detecting poses in the webcam video

--- a/examples/bodyPose-skeleton/sketch.js
+++ b/examples/bodyPose-skeleton/sketch.js
@@ -21,7 +21,7 @@ function setup() {
 
   // Create the video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Start detecting poses in the webcam video

--- a/examples/bodySegmentation-mask-background/sketch.js
+++ b/examples/bodySegmentation-mask-background/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the video
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   bodySegmentation.detectStart(video, gotResults);

--- a/examples/bodySegmentation-mask-body-parts/sketch.js
+++ b/examples/bodySegmentation-mask-body-parts/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the video
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   bodySegmentation.detectStart(video, gotResults);

--- a/examples/bodySegmentation-mask-person/sketch.js
+++ b/examples/bodySegmentation-mask-person/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the video
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   bodySegmentation.detectStart(video, gotResults);

--- a/examples/bodySegmentation-select-bodypart/sketch.js
+++ b/examples/bodySegmentation-select-bodypart/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the video
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   bodySegmentation.detectStart(video, gotResults);
@@ -33,9 +33,11 @@ function draw() {
   image(video, 0, 0);
   if (segmentation) {
     let gridSize = 10;
-    for (let x=0; x < video.width; x += gridSize) {
-      for (let y=0; y < video.height; y += gridSize) {
-        if (segmentation.data[y * video.width + x] == bodySegmentation.TORSO_FRONT) {
+    for (let x = 0; x < video.width; x += gridSize) {
+      for (let y = 0; y < video.height; y += gridSize) {
+        if (
+          segmentation.data[y * video.width + x] == bodySegmentation.TORSO_FRONT
+        ) {
           fill(255, 0, 0);
           noStroke();
           circle(x, y, gridSize);

--- a/examples/faceMesh-keypoints/sketch.js
+++ b/examples/faceMesh-keypoints/sketch.js
@@ -20,7 +20,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
   // Start detecting faces from the webcam video
   faceMesh.detectStart(video, gotFaces);

--- a/examples/faceMesh-parts/sketch.js
+++ b/examples/faceMesh-parts/sketch.js
@@ -20,7 +20,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
   // Start detecting faces from the webcam video
   faceMesh.detectStart(video, gotFaces);

--- a/examples/handPose-detect-start-stop/sketch.js
+++ b/examples/handPose-detect-start-stop/sketch.js
@@ -20,7 +20,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 }
 

--- a/examples/handPose-keypoints/sketch.js
+++ b/examples/handPose-keypoints/sketch.js
@@ -19,7 +19,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
   // start detecting hands from the webcam video
   handPose.detectStart(video, gotHands);

--- a/examples/handPose-parts/sketch.js
+++ b/examples/handPose-parts/sketch.js
@@ -22,7 +22,7 @@ function setup() {
   createCanvas(640, 480);
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
   // Start detecting hands from the webcam video
   handPose.detectStart(video, gotHands);

--- a/examples/imageClassifier-teachable-machine/sketch.js
+++ b/examples/imageClassifier-teachable-machine/sketch.js
@@ -26,7 +26,7 @@ function setup() {
 
   // Create the webcam video and hide it
   video = createCapture(VIDEO, { flipped: true });
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Start detecting objects in the video

--- a/examples/imageClassifier-webcam/sketch.js
+++ b/examples/imageClassifier-webcam/sketch.js
@@ -25,6 +25,7 @@ function setup() {
 
   // Using webcam feed as video input, hiding html element to avoid duplicate with canvas
   video = createCapture(VIDEO);
+  video.size(640, 480);
   video.hide();
   classifier.classifyStart(video, gotResult);
 }

--- a/examples/neuralNetwork-load-model/sketch.js
+++ b/examples/neuralNetwork-load-model/sketch.js
@@ -23,7 +23,7 @@ function setup() {
 
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // For this example to work across all browsers

--- a/examples/neuralNetwork-train-and-save/sketch.js
+++ b/examples/neuralNetwork-train-and-save/sketch.js
@@ -34,7 +34,7 @@ function setup() {
 
   // Create the webcam video and hide it
   video = createCapture(VIDEO);
-  video.size(width, height);
+  video.size(640, 480);
   video.hide();
 
   // Setup the UI buttons for training


### PR DESCRIPTION
This PR changes the p5 video resolution in the example sketches. The video size is now set to a fixed value instead of inheriting the canvas size. Thank you @MOQN for the suggestion.

Orignal:
```js
video = createCapture(VIDEO);
video.size(width, height);
```

New:
```js
video = createCapture(VIDEO);
video.size(640, 480);
```