### PR TITLE
BodySegmentation: Change enum to PERSON

### DIFF
--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -185,7 +185,7 @@ class BodySegmentation {
 
       // add constants to the instance variable
       this.BACKGROUND = 0;
-      this.BODY = 255;
+      this.PERSON = 255;
 
     }
 


### PR DESCRIPTION
I realized that the possible mask types are "person", "background", "parts" - so imho it'd make more sense to go with the same word as the constant for pixels that contain a body/person.