### PR TITLE
Fix body pose bugs

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -208,6 +208,17 @@ class BodyPose {
           modelConfig.modelType =
             poseDetection.movenet.modelType.MULTIPOSE_LIGHTNING;
       }
+      this.runtimeConfig = handleOptions(
+        this.config,
+        {
+          flipHorizontal: {
+            type: "boolean",
+            alias: "flipped",
+            default: false,
+          },
+        },
+        "bodyPose"
+      );
     }
 
     // Load the detector model
@@ -249,6 +260,9 @@ class BodyPose {
     let result = predictions;
     // modify the raw tfjs output to a more usable format
     this.renameScoreToConfidence(result);
+    if (this.runtimeConfig.flipHorizontal) {
+      this.mirrorKeypoints(this.detectMedia, result);
+    }
     this.addKeypoints(result);
     this.resizeBoundingBoxes(result, image.width, image.height);
 
@@ -304,6 +318,9 @@ class BodyPose {
       );
       let result = predictions;
       this.renameScoreToConfidence(result);
+      if (this.runtimeConfig.flipHorizontal) {
+        this.mirrorKeypoints(this.detectMedia, result);
+      }
       this.addKeypoints(result);
       this.resizeBoundingBoxes(
         result,
@@ -340,6 +357,19 @@ class BodyPose {
           objectRenameKey(keypoint, "score", "confidence");
         });
       }
+
+  /**
+   * Mirror the keypoints around x-axis.
+   * @param {HTMLVideoElement | HTMLImageElement | HTMLCanvasElement} detectMedia
+   * @param {Object} poses - the original detection results.
+   * @private
+   */
+  mirrorKeypoints(detectMedia, poses) {
+    const mediaWidth = detectMedia.width;
+    poses.forEach((pose) => {
+      pose.keypoints.forEach((keypoint) => {
+        keypoint.x = mediaWidth - keypoint.x;
+      });
     });
   }
 

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -357,6 +357,9 @@ class BodyPose {
           objectRenameKey(keypoint, "score", "confidence");
         });
       }
+      if (pose.score) objectRenameKey(pose, "score", "confidence");
+    });
+  }
 
   /**
    * Mirror the keypoints around x-axis.

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -258,6 +258,15 @@ class BodyPose {
     let result = predictions;
     // modify the raw tfjs output to a more usable format
     this.renameScoreToConfidence(result);
+    if (this.modelName === "MoveNet" && isVideo(image)) {
+      this.resizeKeypoints(
+        result,
+        image.videoWidth,
+        image.videoHeight,
+        image.width,
+        image.height
+      );
+    }
     if (this.runtimeConfig.flipHorizontal) {
       this.mirrorKeypoints(result, image.width);
     }
@@ -313,6 +322,15 @@ class BodyPose {
       const predictions = await this.model.estimatePoses(this.detectMedia);
       let result = predictions;
       this.renameScoreToConfidence(result);
+      if (this.modelName === "MoveNet" && isVideo(this.detectMedia)) {
+        this.resizeKeypoints(
+          result,
+          this.detectMedia.videoWidth,
+          this.detectMedia.videoHeight,
+          this.detectMedia.width,
+          this.detectMedia.height
+        );
+      }
       if (this.runtimeConfig.flipHorizontal) {
         this.mirrorKeypoints(result, this.detectMedia.width);
       }
@@ -366,6 +384,24 @@ class BodyPose {
     poses.forEach((pose) => {
       pose.keypoints.forEach((keypoint) => {
         keypoint.x = mediaWidth - keypoint.x;
+      });
+    });
+  }
+
+  /**
+   * Resize the keypoints output of moveNet model to match the display size.
+   *
+   * @param {Object} poses - the original detection results.
+   * @param {HTMLVideoElement} mediaWidth - the actual width of the video.
+   * @param {HTMLVideoElement} mediaHeight- the actual height of the video.
+   * @param {HTMLVideoElement} displayWidth - the display width of the video.
+   * @param {HTMLVideoElement} displayHeight - the display height of the video.
+   */
+  resizeKeypoints(poses, mediaWidth, mediaHeight, displayWidth, displayHeight) {
+    poses.forEach((pose) => {
+      pose.keypoints.forEach((keypoint) => {
+        keypoint.x = (keypoint.x / mediaWidth) * displayWidth;
+        keypoint.y = (keypoint.y / mediaHeight) * displayHeight;
       });
     });
   }


### PR DESCRIPTION
This PR fixes various bugs in the bodyPose model.
- Rename the confidence value for the entire pose from `score` to `confidence`.
- Fix the [`flipped` and `flipHorizontal` not working issue](https://github.com/ml5js/ml5-next-gen/pull/127#issuecomment-2236929386) by implementing mirroring on ml5's end.
- Fix the keypoints not resizing issue on `MoveNet` model.
  - It seems like `MoveNet` model's keypoints are scaled on the video's intrinsic size ("videoWidth" and "videoHeight") instead of display size ("width" and "height"). This contradicts the behavior of `handPose`, `faceMesh`, and the `BlazePose` model. This fix rescales the keypoints to the video display size.