### PR TITLE
reorder metadata legend before results

### DIFF
--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -1102,7 +1102,12 @@ class DiyNeuralNetwork {
     if (meta !== null) {
       const label = Object.keys(meta.outputs)[0];
       const vals = Object.entries(meta.outputs[label].legend);
-
+      vals.sort((a, b) => {
+        return (
+          b[1].reduce((acc, curr) => acc * 2 + curr, 0) -
+          a[1].reduce((acc, curr) => acc * 2 + curr, 0)
+        );
+      });
       const formattedResults = unformattedResults.map((unformattedResult) => {
         return vals
           .map((item, idx) => {

--- a/src/NeuralNetwork/index.js
+++ b/src/NeuralNetwork/index.js
@@ -1102,12 +1102,14 @@ class DiyNeuralNetwork {
     if (meta !== null) {
       const label = Object.keys(meta.outputs)[0];
       const vals = Object.entries(meta.outputs[label].legend);
+      // sort the legend array results by each item's one-hot encoding
       vals.sort((a, b) => {
         return (
           b[1].reduce((acc, curr) => acc * 2 + curr, 0) -
           a[1].reduce((acc, curr) => acc * 2 + curr, 0)
         );
       });
+
       const formattedResults = unformattedResults.map((unformattedResult) => {
         return vals
           .map((item, idx) => {


### PR DESCRIPTION
This PR fixes #180 by sorting `Object.entries(legend)` via the one hot array, ensuring that its ordering matches the ordering of `unformattedResults`.