### PR TITLE
change upload script ml5 version number

### DIFF
--- a/scripts/uploadExamples.js
+++ b/scripts/uploadExamples.js
@@ -212,9 +212,10 @@ function createFolderObject(folderID, folderPath) {
  * @returns {string} The content with the CDN URL.
  */
 function replaceWithCdnURL(content) {
+  const version = ml5Version.split(".")[0];
   return content.replace(
     "../../dist/ml5.js",
-    `https://unpkg.com/ml5@${ml5Version}/dist/ml5.min.js`
+    `https://unpkg.com/ml5@${version}/dist/ml5.min.js`
   );
 }
 


### PR DESCRIPTION
Instead of specific version numbers like `ml5@1.0.1`, use `ml5@1`.

This way if people make copies of the example scripts, the ml5 version will automatically roll over to the newest non-breaking release.