### PR TITLE
update dev environment setup instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ yarn
 yarn start
 ```
 
+_Note: If you are using nvm and run into issues with yarn versioning, it might be due to interference from another yarn installation. You can list your node.js installations with_ `nvm ls` _and remove all other node.js installations with yarn using the_ `nvm uninstall <version>` _command. Then, repeat the above steps._
+
 You should see something similar to this in the terminal:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ yarn
 yarn start
 ```
 
-_Note: If you are using nvm and run into issues with yarn versioning, it might be due to interference from another yarn installation. You can list your node.js installations with_ `nvm ls` _and remove all other node.js installations with yarn using the_ `nvm uninstall <version>` _command. Then, repeat the above steps._
+_Note: If you are using nvm and run into issues with yarn versioning, it might be due to interference from another yarn installation. On macOS or Linux, use the_ `which yarn` _command to find the location interfering yarn installation. You should see something like_ `Users/user/.nvm/versions/node/<node_version>/bin/yarn`_. You can remove node.js installation using the_ `nvm uninstall <node_version>` _command. Lastly, repeat the setup guide._
 
 You should see something similar to this in the terminal:
 


### PR DESCRIPTION
The PR updates the dev environment setup instruction to include a workaround for potential yarn versioning issues. 

cc @sharellb Just FYI I think the issue we ran into might be caused by a different version of yarn installed in another nvm installation of node.js. However, I am not able to consistently reproduce the error. The fix `npm i -g --force yarn` also did not always work. If someone runs into this problem again, I think the best workaround for now is to just uninstall other nvm node.js installations that have the wrong version of yarn.


