### PR TITLE
remove experimental warning in console message

### DIFF
--- a/src/utils/communityStatement.js
+++ b/src/utils/communityStatement.js
@@ -6,12 +6,6 @@ export default () => {
 🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈🌈
 🌟 Thank you for using ml5.js v${version} 🌟
 
-❗❗❗
-This is an experimental and unstable version 
-of ml5.js. Please feel free to report any bugs
-via the methods listed below.
-❗❗❗
-
 Please read our community statement to ensure 
 that the use of this software reflects the values 
 of the ml5.js community:


### PR DESCRIPTION
This PR removes the experimental warning in the console message since we are past `1.0.0`.