### PR TITLE
handle min = max case during data normalization

### DIFF
--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -284,7 +284,6 @@ class NeuralNetworkData {
     const dataLength = dataRaw.length;
     // the copy of the inputs.meta[inputOrOutput]
     const inputMeta = Object.assign({}, inputOrOutputMeta);
-
     // normalized output object
     const normalized = {};
     Object.keys(inputMeta).forEach((k) => {
@@ -343,6 +342,11 @@ class NeuralNetworkData {
       return normalized;
     }
 
+    if (min === max) {
+      console.warn(
+        "🟪 ml5.js NeuralNetwork warns: Normalization failed, all data entries for an input parameter are identical (min === max). The data for this input parameter will be set to 0, effectively removing it from the model. Please check your input data."
+      );
+    }
     // if the dtype is a number
     if (inputArray.every((v) => typeof v === "number")) {
       const normalized = inputArray.map((v) =>

--- a/src/NeuralNetwork/NeuralNetworkUtils.js
+++ b/src/NeuralNetwork/NeuralNetworkUtils.js
@@ -11,6 +11,10 @@ class NeuralNetworkUtils {
    */
   // eslint-disable-next-line class-methods-use-this
   normalizeValue(value, min, max) {
+    // When min is equal to max, set everything to 0
+    if (min === max) {
+      return 0;
+    }
     return (value - min) / (max - min);
   }
 

--- a/src/NeuralNetwork/NeuralNetworkUtils.js
+++ b/src/NeuralNetwork/NeuralNetworkUtils.js
@@ -4,12 +4,11 @@ class NeuralNetworkUtils {
   }
 
   /**
-   * normalizeValue
-   * @param {*} value
-   * @param {*} min
-   * @param {*} max
+   * Normalize a value between min and max, return 0 if min === max
+   * @param {number} value - The value to normalize
+   * @param {number} min - The minimum bound
+   * @param {number} max - The maximum bound
    */
-  // eslint-disable-next-line class-methods-use-this
   normalizeValue(value, min, max) {
     // When min is equal to max, set everything to 0
     if (min === max) {
@@ -26,6 +25,9 @@ class NeuralNetworkUtils {
    */
   // eslint-disable-next-line class-methods-use-this
   unnormalizeValue(value, min, max) {
+    if (min === max) {
+      return min;
+    }
     return value * (max - min) + min;
   }
 


### PR DESCRIPTION
This PR addresses issue #204 by adding a check for `min === max` in `normalizeValue`, preventing the divide by zero situation.