### PR TITLE
BlazePose 3d named keypoints

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -471,6 +471,21 @@ class BodyPose {
           confidence: keypoint.confidence,
         };
       });
+
+      // Add 3D keypoints when using BlazePose
+      if (pose.keypoints3D) {
+        pose.keypoints3D.forEach((keypoint) => {
+          pose[keypoint.name] = {
+            ...pose[keypoint.name],
+            keypoint3D: {
+              x: keypoint.x,
+              y: keypoint.y,
+              z: keypoint.z,
+              confidence: keypoint.confidence,
+            },
+          };
+        });
+      }
     });
   }
 

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -470,7 +470,6 @@ class BodyPose {
           y: keypoint.y,
           confidence: keypoint.confidence,
         };
-        if (keypoint.z) pose[keypoint.name].z = keypoint.z;
       });
     });
   }

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -1,11 +1,21 @@
-// Copyright (c) 2020-2023 ml5
-//
-// This software is released under the MIT License.
-// https://opensource.org/licenses/MIT
+/**
+ * @license
+ * Copyright (c) 2020-2024 ml5
+ * This software is released under the ml5.js License.
+ * https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ */
 
-/*
- * FaceMesh: Face landmarks tracking in the browser
- * Ported and integrated from all the hard work by: https://github.com/tensorflow/tfjs-models/tree/master/face-landmarks-detection
+/**
+ * @file HandPose
+ *
+ * The file contains the main code of FaceMesh, a pretrained face landmark
+ * estimation model that detects and tracks faces and facial features with landmark points.
+ * The FaceMesh model is built on top of the face detection model of TensorFlow.
+ *
+ * TensorFlow Face Detection repo:
+ * https://github.com/tensorflow/tfjs-models/tree/master/face-detection
+ * ml5.js BodyPose reference documentation:
+ * https://docs.ml5js.org/#/reference/facemesh
  */
 
 import * as tf from "@tensorflow/tfjs";


### PR DESCRIPTION
This PR removes the `z` values from the named keypoints and adds a `keypoint3D` object to the named keypoints for `BlazePose` mode of `BodyPose`. 

See #210 and https://github.com/ml5js/ml5-website-v02-docsify/issues/181 for additional detail and reasoning. 