### PR TITLE
BlazePose named 3d keypoints

### DIFF
--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -471,6 +471,21 @@ class BodyPose {
           confidence: keypoint.confidence,
         };
       });
+
+      // Add the 3d keypoints if in BlazePose mode
+      if (pose.keypoints3D) {
+        pose.keypoints3D.forEach((keypoint) => {
+          pose[keypoint.name] = {
+            ...pose[keypoint.name],
+            keypoint3D: {
+              x: keypoint.x,
+              y: keypoint.y,
+              z: keypoint.z,
+              confidence: keypoint.confidence,
+            },
+          };
+        });
+      }
     });
   }
 

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -470,7 +470,6 @@ class BodyPose {
           y: keypoint.y,
           confidence: keypoint.confidence,
         };
-        if (keypoint.z) pose[keypoint.name].z = keypoint.z;
       });
     });
   }


### PR DESCRIPTION
This PR removes the z values from the named keypoints and adds a keypoint3D object to the named keypoints for BlazePose mode of BodyPose.

See https://github.com/ml5js/ml5-next-gen/issues/210 and https://github.com/ml5js/ml5-website-v02-docsify/issues/181 for additional detail and reasoning.