### PR TITLE
Added `bodySegmentation.getPartsId()`

### DIFF
--- a/examples/bodySegmentation-select-body-parts/sketch.js
+++ b/examples/bodySegmentation-select-body-parts/sketch.js
@@ -32,11 +32,12 @@ function draw() {
   background(255);
   image(video, 0, 0);
   if (segmentation) {
+    let parts = bodySegmentation.getPartsId()
     let gridSize = 10;
     for (let x = 0; x < video.width; x += gridSize) {
       for (let y = 0; y < video.height; y += gridSize) {
         if (
-          segmentation.data[y * video.width + x] == bodySegmentation.TORSO_FRONT
+          segmentation.data[y * video.width + x] == parts.TORSO_FRONT
         ) {
           fill(255, 0, 0);
           noStroke();

--- a/examples/bodySegmentation-select-body-parts/sketch.js
+++ b/examples/bodySegmentation-select-body-parts/sketch.js
@@ -32,13 +32,11 @@ function draw() {
   background(255);
   image(video, 0, 0);
   if (segmentation) {
-    let parts = bodySegmentation.getPartsId()
+    let parts = bodySegmentation.getPartsId();
     let gridSize = 10;
     for (let x = 0; x < video.width; x += gridSize) {
       for (let y = 0; y < video.height; y += gridSize) {
-        if (
-          segmentation.data[y * video.width + x] == parts.TORSO_FRONT
-        ) {
+        if (segmentation.data[y * video.width + x] == parts.TORSO_FRONT) {
           fill(255, 0, 0);
           noStroke();
           circle(x, y, gridSize);

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -131,10 +131,14 @@ class BodySegmentation {
         "bodySegmentation"
       );
 
-      // add body part constants to the instance variable
-      for (let key in BODYPIX_PALETTE) {
-        this[key] = BODYPIX_PALETTE[key].id;
-      }
+      // Add function to return parts' key and id
+      this.getPartsId = () => {
+        let parts = {};
+        for (let key in BODYPIX_PALETTE) {
+         parts[key] = BODYPIX_PALETTE[key].id;
+       }
+       return parts;
+     }
     } else {
       pipeline = tfBodySegmentation.SupportedModels.MediaPipeSelfieSegmentation;
       modelConfig = handleOptions(

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -135,10 +135,10 @@ class BodySegmentation {
       this.getPartsId = () => {
         let parts = {};
         for (let key in BODYPIX_PALETTE) {
-         parts[key] = BODYPIX_PALETTE[key].id;
-       }
-       return parts;
-     }
+          parts[key] = BODYPIX_PALETTE[key].id;
+        }
+        return parts;
+      };
     } else {
       pipeline = tfBodySegmentation.SupportedModels.MediaPipeSelfieSegmentation;
       modelConfig = handleOptions(
@@ -184,10 +184,6 @@ class BodySegmentation {
         },
         "bodySegmentation"
       );
-
-      // add constants to the instance variable
-      this.BACKGROUND = 0;
-      this.PERSON = 255;
     }
 
     await tf.ready();


### PR DESCRIPTION
@shiffman @ziyuan-linn 
As we discussed in https://github.com/ml5js/ml5-website-v02-docsify/issues/88 & https://github.com/ml5js/ml5-next-gen/pull/139 , this PR is to wrap the palette in a public method called `getPartsId()` within the `bodySegmentation`. This method will return an object containing all the constants as key-value pairs, similar to the `getSkeleton()` method in BodyPose.
![CleanShot 2024-10-14 at 15 06 00@2x](https://github.com/user-attachments/assets/71d3dee8-78df-49be-bcc8-1d6d1def4a28)
As we are [removing the `properties` section from the model documentation page](https://github.com/ml5js/ml5-website-v02-docsify/pull/188), this public method ensures that the data remains accessible to all users and aligns with the consistency of other models. 

