### PR TITLE
add `FaceMesh.getTriangles`

### DIFF
--- a/examples/faceMesh-triangle-mesh/index.html
+++ b/examples/faceMesh-triangle-mesh/index.html
@@ -1,0 +1,22 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates drawing a triangular mesh using ml5.faceMesh.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ml5.js faceMesh Triangle Mesh Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.4/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/faceMesh-triangle-mesh/sketch.js
+++ b/examples/faceMesh-triangle-mesh/sketch.js
@@ -1,0 +1,60 @@
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * This example demonstrates drawing a triangular mesh using ml5.faceMesh.
+ */
+
+let faceMesh;
+let video;
+let faces = [];
+let options = { maxFaces: 1, refineLandmarks: false, flipHorizontal: false };
+let triangles;
+
+function preload() {
+  // Load the faceMesh model
+  faceMesh = ml5.faceMesh(options);
+}
+
+function setup() {
+  createCanvas(640, 480);
+  // Create the webcam video and hide it
+  video = createCapture(VIDEO);
+  video.size(640, 480);
+  video.hide();
+  // Load the triangle indices for drawing the mesh
+  triangles = faceMesh.getTriangles();
+  // Start detecting faces from the webcam video
+  faceMesh.detectStart(video, gotFaces);
+}
+
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  // Draw all the triangles
+  for (let i = 0; i < faces.length; i++) {
+    let face = faces[i];
+    for (let j = 0; j < triangles.length; j++) {
+      let indices = triangles[j];
+      let pointAIndex = indices[0];
+      let pointBIndex = indices[1];
+      let pointCIndex = indices[2];
+      let pointA = face.keypoints[pointAIndex];
+      let pointB = face.keypoints[pointBIndex];
+      let pointC = face.keypoints[pointCIndex];
+
+      noFill();
+      stroke(0, 0, 255);
+      strokeWeight(1);
+      triangle(pointA.x, pointA.y, pointB.x, pointB.y, pointC.x, pointC.y);
+    }
+  }
+}
+
+// Callback function for when faceMesh outputs data
+function gotFaces(results) {
+  // Save the output to the faces variable
+  faces = results;
+}

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -323,6 +323,29 @@ class FaceMesh {
     }
     return faces;
   }
+
+  /**
+   * Returns the trio of keypoint indices that form each triangle in the face mesh.
+   * @returns {number[][]} an array of triangles, each containing three keypoint indices.
+   * @public
+   */
+  getTriangles() {
+    const connectingPairs = faceLandmarksDetection.util.getAdjacentPairs(
+      faceLandmarksDetection.SupportedModels.MediaPipeFaceMesh
+    );
+
+    const triangles = [];
+    for (let i = 0; i < connectingPairs.length; i += 3) {
+      const triangle = [
+        connectingPairs[i][0],
+        connectingPairs[i + 1][0],
+        connectingPairs[i + 2][0],
+      ];
+      triangles.push(triangle);
+    }
+
+    return triangles;
+  }
 }
 
 /**


### PR DESCRIPTION
This PR adds the `FaceMesh.getTriangles` function. It provides a nested array of keypoint indices. The indices are grouped in threes, indicating which three keypoints form a triangle. 

Changes:
- Implement `getTriangles` function
- Add triangle mesh example

See #211 for details. 