### PR TITLE
Fixes #144: Corrected lip alignment for facemesh keypoints

### DIFF
--- a/examples/faceMesh-shapes-from-parts/sketch.js
+++ b/examples/faceMesh-shapes-from-parts/sketch.js
@@ -34,8 +34,13 @@ function draw() {
     let face = faces[j];
 
     noFill();
-
     // draw the lips
+    face.lips.keypoints.splice(10, 0, face.lips.keypoints[20]);
+    face.lips.keypoints.splice(
+      32,
+      0,
+      face.lips.keypoints[face.lips.keypoints.length - 1]
+    );
     stroke(255, 0, 255);
     beginShape();
     for (let i = 0; i < face.lips.keypoints.length; i++) {

--- a/examples/faceMesh-shapes-from-parts/sketch.js
+++ b/examples/faceMesh-shapes-from-parts/sketch.js
@@ -35,12 +35,12 @@ function draw() {
 
     noFill();
     // draw the lips
-    face.lips.keypoints.splice(10, 0, face.lips.keypoints[20]);
+    face.lips.keypoints.splice(10, 0, face.lips.keypoints[20]); // Extreme left point for lower outer lip
     face.lips.keypoints.splice(
       32,
       0,
       face.lips.keypoints[face.lips.keypoints.length - 1]
-    );
+    ); // Extreme left point for lower inner lip
     stroke(255, 0, 255);
     beginShape();
     for (let i = 0; i < face.lips.keypoints.length; i++) {


### PR DESCRIPTION
<div style={display:"flex"}>
<div style={}>
<h1>
Before
</h1>
<img width="212" alt="image" src="https://github.com/user-attachments/assets/2f85a03b-c182-4954-b38f-a4a609bebaef" />

</div>

<div>
<h1>
After
</h1>

<img width="207" alt="image" src="https://github.com/user-attachments/assets/24a0d275-0ee2-410d-ac22-f82bb6f3bb12" />

</div>
</div>



### Problem
The facemesh model had an issue with the lips. The **upper lips** had more keypoints than the **lower lips**, which caused:
- Asymmetry in the lip shape.
- Gaps or improper alignment when drawing the lips.
- it wont be a problem if it were just points but we are doing it in a single stroke which made it look unexpected.

### Solution
To fix this, I added the **missing extreme left points** for the lower lips:
1. For the **outer lower lip**, I used the extreme left point from the upper lip (keypoint `20`) and added it to the lower lip at position `10`.
2. For the **inner lower lip**, I used the last keypoint from the upper lip and added it to the lower lip at position `32`.

This ensures the **upper and lower lips now have the same number of keypoints** and align perfectly.

### Code Changes
I added the following lines:
```javascript
face.lips.keypoints.splice(10, 0, face.lips.keypoints[20]); // missing point for outer lower lip
face.lips.keypoints.splice(32, 0, face.lips.keypoints[face.lips.keypoints.length - 1]); // missing point for inner lower lip
