### PR TITLE
Add support for OffscreenCanvas

### DIFF
--- a/src/utils/handleArguments.js
+++ b/src/utils/handleArguments.js
@@ -7,7 +7,7 @@ import * as tf from "@tensorflow/tfjs";
 /**
  * Standard input accepted by most TensorFlow models.
  * @typedef InputImage
- * @type {ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | tf.Tensor3D}
+ * @type {ImageData | HTMLImageElement | HTMLCanvasElement | OffscreenCanvas | HTMLVideoElement | tf.Tensor3D}
  */
 
 /**
@@ -40,13 +40,13 @@ export const isAudio = (img) => {
 };
 
 /**
- * Check if a variable is an HTMLCanvasElement.
+ * Check if a variable is an HTMLCanvasElement or OffscreenCanvas
  * @param {any} img
  * @returns {img is HTMLCanvasElement}
  */
 export const isCanvas = (img) => {
   return (
-    typeof HTMLCanvasElement !== "undefined" && img instanceof HTMLCanvasElement
+    typeof HTMLCanvasElement !== "undefined" && (img instanceof HTMLCanvasElement || img instanceof OffscreenCanvas)
   );
 };
 


### PR DESCRIPTION
Tensorflow will accept "canvas like" objects, including OffscreenCanvas.

https://github.com/tensorflow/tfjs/blob/2644bd0d6cea677f80e44ed4a44bea5e04aabeb3/tfjs-core/src/ops/browser.ts#L98

I tested if this with the ml5 image classifier example and it does work!