### PR TITLE
Turn "const" into "let" in example code

### DIFF
--- a/examples/faceMesh-uv-map/sketch.js
+++ b/examples/faceMesh-uv-map/sketch.js
@@ -54,9 +54,9 @@ function draw() {
       let a = face.keypoints[indexA];
       let b = face.keypoints[indexB];
       let c = face.keypoints[indexC];
-      const uvA = { x: uvCoords[indexA][0], y: uvCoords[indexA][1] };
-      const uvB = { x: uvCoords[indexB][0], y: uvCoords[indexB][1] };
-      const uvC = { x: uvCoords[indexC][0], y: uvCoords[indexC][1] };
+      let uvA = { x: uvCoords[indexA][0], y: uvCoords[indexA][1] };
+      let uvB = { x: uvCoords[indexB][0], y: uvCoords[indexB][1] };
+      let uvC = { x: uvCoords[indexC][0], y: uvCoords[indexC][1] };
       vertex(a.x, a.y, uvA.x, uvA.y);
       vertex(b.x, b.y, uvB.x, uvB.y);
       vertex(c.x, c.y, uvC.x, uvC.y);

--- a/examples/neuralNetwork-color-classifier/sketch.js
+++ b/examples/neuralNetwork-color-classifier/sketch.js
@@ -58,7 +58,7 @@ function setup() {
   classifier.normalizeData();
 
   // Step 6: train your neural network
-  const trainingOptions = {
+  let trainingOptions = {
     epochs: 32,
     batchSize: 12,
   };
@@ -71,7 +71,7 @@ function finishedTraining() {
 
 // Step 8: make a classification
 function classify() {
-  const input = [r, g, b];
+  let input = [r, g, b];
   classifier.classify(input, handleResults);
 }
 

--- a/examples/neuralNetwork-load-model/sketch.js
+++ b/examples/neuralNetwork-load-model/sketch.js
@@ -36,7 +36,7 @@ function setup() {
   };
   classifier = ml5.neuralNetwork(classifierOptions);
 
-  const modelDetails = {
+  let modelDetails = {
     model: "model/model.json",
     metadata: "model/model_meta.json",
     weights: "model/model.weights.bin",

--- a/examples/neuroEvolution-sensors/creature.js
+++ b/examples/neuroEvolution-sensors/creature.js
@@ -69,7 +69,7 @@ class Creature {
     }
 
     // Predicting the force to apply
-    const outputs = this.brain.predictSync(inputs);
+    let outputs = this.brain.predictSync(inputs);
     let angle = outputs[0].value * TWO_PI;
     let magnitude = outputs[1].value;
     let force = p5.Vector.fromAngle(angle).setMag(magnitude);

--- a/examples/soundClassifier-teachable-machine/sketch.js
+++ b/examples/soundClassifier-teachable-machine/sketch.js
@@ -14,7 +14,7 @@ let classifier;
 let predictedSound = "";
 
 // Link to custom Teachable Machine model
-const modelJson = "https://teachablemachine.withgoogle.com/models/FvsFiSwHW/";
+let modelJson = "https://teachablemachine.withgoogle.com/models/FvsFiSwHW/";
 
 function preload() {
   // Load Teachable Machine model


### PR DESCRIPTION
The p5 reference does not currently introduce "const", and the containing example codes don't make use of it either (as far as I could tell). This is converting all our example code to "let".

There are only a few places where "const" is used, and its application there isn't very consistent either [1], so I think removing those for now I fine.

[1] e.g. in neuralNetwork-load-model, `classifierOptions` is `let` but `modelDetails` is `const`