### PR TITLE
Add a Readme file to examples, with link to sketches on web editor

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,43 @@
+![ml5](https://user-images.githubusercontent.com/10605821/41332516-2ee26714-6eac-11e8-83e4-a40b8761e764.png)
+
+## ml5.js Examples
+
+**Explore in the p5.js Web Editor**
+
+Jump right into experimenting with ml5.js — no local setup needed. Browse and run these example sketches directly in the p5.js Web Editor:
+
+* [bodyPose-blazePose-keypoints](https://editor.p5js.org/ml5/sketches/OukJYAJAb)
+* [bodyPose-blazePose-skeleton](https://editor.p5js.org/ml5/sketches/KWgsAbgkk)
+* [bodyPose-keypoints](https://editor.p5js.org/ml5/sketches/c8sl_hGmN)
+* [bodyPose-skeletal-connections](https://editor.p5js.org/ml5/sketches/YBuqxIH1S)
+* [bodySegmentation-mask-background](https://editor.p5js.org/ml5/sketches/KNsdeNhrp)
+* [bodySegmentation-mask-body-parts](https://editor.p5js.org/ml5/sketches/ruoyal-RC)
+* [bodySegmentation-mask-person](https://editor.p5js.org/ml5/sketches/h6TN8umP5)
+* [bodySegmentation-select-body-parts](https://editor.p5js.org/ml5/sketches/R5rug0HKk)
+* [faceMesh-bounding-box](https://editor.p5js.org/ml5/sketches/fMCIspRD7_)
+* [faceMesh-keypoints](https://editor.p5js.org/ml5/sketches/lCurUW1TT)
+* [faceMesh-keypoints-from-parts](https://editor.p5js.org/ml5/sketches/EjynWxazD4)
+* [faceMesh-parts](https://editor.p5js.org/ml5/sketches/9y9W7eAee)
+* [faceMesh-parts-bounding-box](https://editor.p5js.org/ml5/sketches/F9jRILxn2)
+* [faceMesh-shapes-from-parts](https://editor.p5js.org/ml5/sketches/6qj0M3ElM)
+* [faceMesh-single-image](https://editor.p5js.org/ml5/sketches/lqQZrDJHF)
+* [faceMesh-triangle-mesh](https://editor.p5js.org/ml5/sketches/8mT3aRjUe)
+* [faceMesh-uv-map](https://editor.p5js.org/ml5/sketches/-H7dLfUqC)
+* [handPose-detect-start-stop](https://editor.p5js.org/ml5/sketches/W9vFFT5RM)
+* [handPose-keypoints](https://editor.p5js.org/ml5/sketches/QGH3dwJ1A)
+* [handPose-parts](https://editor.p5js.org/ml5/sketches/DNbSiIYKB)
+* [handPose-single-image](https://editor.p5js.org/ml5/sketches/8VK_l3XwE)
+* [handPose-skeletal-connections](https://editor.p5js.org/ml5/sketches/fnboooD-K)
+* [imageClassifier-single-image](https://editor.p5js.org/ml5/sketches/pjPr6XmPY)
+* [imageClassifier-teachable-machine](https://editor.p5js.org/ml5/sketches/VvGXajA36)
+* [imageClassifier-webcam](https://editor.p5js.org/ml5/sketches/K0sjaEO19)
+* [neuralNetwork-color-classifier](https://editor.p5js.org/ml5/sketches/eGHBdmCLe)
+* [neuralNetwork-load-model](https://editor.p5js.org/ml5/sketches/U-aljtx7x)
+* [neuralNetwork-mouse-gesture](https://editor.p5js.org/ml5/sketches/FdXAgrA3N)
+* [neuralNetwork-train-and-save](https://editor.p5js.org/ml5/sketches/rR51vvi-u)
+* [neuroEvolution-flappy-bird](https://editor.p5js.org/ml5/sketches/VXSvfFiQF)
+* [neuroEvolution-sensors](https://editor.p5js.org/ml5/sketches/64yhABxVb)
+* [neuroEvolution-steering](https://editor.p5js.org/ml5/sketches/eTJ1nO0O9)
+* [sentiment](https://editor.p5js.org/ml5/sketches/hopIvsCGL)
+* [soundClassifier-speech-command](https://editor.p5js.org/ml5/sketches/HUm7NYMW3)
+* [soundClassifier-teachable-machine](https://editor.p5js.org/ml5/sketches/mXeiNXSTU)


### PR DESCRIPTION
This makes it easier to go from the repository to running the example sketches, without setting up a local development environment. (See #249 for discussion) In the future, it would be a nice addition to the uploadExamples.js script, if it'd programmatically update the Markdown file.