### PR TITLE
Fix memory leak and input sizing for SelfieSegmentation

### DIFF
--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -259,6 +259,13 @@ class BodySegmentation {
     }
     result.mask = this.generateP5Image(result.maskImageData);
 
+    //dispose segmentation tensors
+    segmentation.map((singleSegmentation) =>
+      singleSegmentation.mask
+        .toTensor()
+        .then((tensor) => tensor.dispose())
+    );
+
     if (callback) callback(result);
     return result;
   }
@@ -360,6 +367,13 @@ class BodySegmentation {
           );
       }
       result.mask = this.generateP5Image(result.maskImageData);
+
+      //dispose segmentation tensors
+      segmentation.map((singleSegmentation) =>
+        singleSegmentation.mask
+          .toTensor()
+          .then((tensor) => tensor.dispose())
+      );
 
       this.detectCallback(result);
       await tf.nextFrame();

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -16,6 +16,7 @@ import BODYPIX_PALETTE from "./BODYPIX_PALETTE";
 import { mediaReady } from "../utils/imageUtilities";
 import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
+import { resizeImageAsTensor } from "../utils/imageUtilities";
 
 class BodySegmentation {
   /**
@@ -209,10 +210,25 @@ class BodySegmentation {
 
     await mediaReady(image, false);
 
+    let inputForSegmenter = image;
+
+    //If using SelfieSegmentation, make sure the input is actually the size the user expects
+    if (
+      this.modelName == "SelfieSegmentation" &&
+      (inputForSegmenter instanceof HTMLVideoElement ||
+        inputForSegmenter instanceof HTMLImageElement)
+    ) {
+      inputForSegmenter = resizeImageAsTensor(image, image.width, image.height);
+    }
+
     const segmentation = await this.model.segmentPeople(
-      image,
+      inputForSegmenter,
       this.runtimeConfig
     );
+
+    if (inputForSegmenter.dispose) {
+      inputForSegmenter.dispose();
+    }
 
     const result = {};
 
@@ -261,9 +277,7 @@ class BodySegmentation {
 
     //dispose segmentation tensors
     segmentation.map((singleSegmentation) =>
-      singleSegmentation.mask
-        .toTensor()
-        .then((tensor) => tensor.dispose())
+      singleSegmentation.mask.toTensor().then((tensor) => tensor.dispose())
     );
 
     if (callback) callback(result);
@@ -317,10 +331,29 @@ class BodySegmentation {
   async detectLoop() {
     await mediaReady(this.detectMedia, false);
     while (!this.signalStop) {
+      let inputForSegmenter = this.detectMedia;
+
+      //If using SelfieSegmentation, make sure the input is actually the size the user expects
+      if (
+        this.modelName == "SelfieSegmentation" &&
+        (inputForSegmenter instanceof HTMLVideoElement ||
+          inputForSegmenter instanceof HTMLImageElement)
+      ) {
+        inputForSegmenter = resizeImageAsTensor(
+          this.detectMedia,
+          this.detectMedia.width,
+          this.detectMedia.height
+        );
+      }
+
       const segmentation = await this.model.segmentPeople(
-        this.detectMedia,
+        inputForSegmenter,
         this.runtimeConfig
       );
+
+      if (inputForSegmenter.dispose) {
+        inputForSegmenter.dispose();
+      }
 
       const result = {};
 
@@ -370,9 +403,7 @@ class BodySegmentation {
 
       //dispose segmentation tensors
       segmentation.map((singleSegmentation) =>
-        singleSegmentation.mask
-          .toTensor()
-          .then((tensor) => tensor.dispose())
+        singleSegmentation.mask.toTensor().then((tensor) => tensor.dispose())
       );
 
       this.detectCallback(result);

--- a/src/utils/imageUtilities.js
+++ b/src/utils/imageUtilities.js
@@ -200,6 +200,24 @@ async function mediaReady(input, nextFrame) {
   }
 }
 
+/**
+ * Useful when models are ignoring the display size of the input HTML element
+ * and instead using the intrinsic dimensions. This function will turn the
+ * input into a tensor with the given dimensions and return it.
+ * @param {HTMLImageElement | HTMLCanvasElement | HTMLVideoElement} input
+ * @param {number} width
+ * @param {number} height
+ * @return {tf.Tensor3D}
+ */
+function resizeImageAsTensor(input, width, height) {
+  return tf.tidy(() => {
+    const sourcePixelsTensor = tf.browser.fromPixels(input);
+    const resized = tf.image.resizeBilinear(sourcePixelsTensor, [height, width]).clipByValue(0, 255);
+
+    return resized;
+  });
+}
+
 export {
   array3DToImage,
   processVideo,
@@ -209,4 +227,5 @@ export {
   flipImage,
   imgToPixelArray,
   mediaReady,
+  resizeImageAsTensor
 };


### PR DESCRIPTION
This PR addresses issues https://github.com/ml5js/ml5-next-gen/issues/262 and https://github.com/ml5js/ml5-next-gen/issues/263, by adding tensor disposal code taken from a [tensorflow example](https://github.com/tensorflow/tfjs-models/blob/18a73420e555a3c1948209ebfa807c7086c7ff0c/depth-estimation/demos/3d_photo/js/depth.js#L174-L176) using `SelfieSegmentation` and resizing input into the model using tensorflow.js methods described in https://github.com/ml5js/ml5-library/issues/1413 and https://github.com/tensorflow/tfjs/issues/2738.