### PR TITLE
Add friendlier message for oneHot error

### DIFF
--- a/src/NeuralNetwork/NeuralNetworkData.js
+++ b/src/NeuralNetwork/NeuralNetworkData.js
@@ -502,6 +502,18 @@ class NeuralNetworkData {
       };
 
       const uniqueVals = _uniqueValuesArray; // [...new Set(this.data.raw.map(obj => obj.xs[prop]))]
+
+      // Validate that we have at least 2 classes for classification
+      if (uniqueVals.length < 2) {
+        throw new Error(
+          `🟪 ml5.js classification error: Classification requires at least 2 different classes, but only found ${
+            uniqueVals.length
+          } class: "${
+            uniqueVals[0] || "undefined"
+          }". Please add training data with multiple different output values.`
+        );
+      }
+
       // get back values from 0 to the length of the uniqueVals array
       const onehotValues = uniqueVals.map((item, idx) => idx);
       // oneHot encode the values in the 1d tensor


### PR DESCRIPTION
As suggested by @gohai.

When users give only one class for classification, they receive an error message: 
`Error in oneHot: depth must be >=2, but it is 1`
Changed it to:
`🟪 ml5.js classification error: Classification requires at least 2 different classes, but only found 1 class: (some class name). Please add training data with multiple different output values.`

Tested by changing the outputs to only one value. E.g., in the neuralNetwork-mouse-gesture example, change every output to "red-ish" to see the error.