### PR TITLE
Fix upload examples

### DIFF
--- a/scripts/uploadExamples.js
+++ b/scripts/uploadExamples.js
@@ -146,7 +146,10 @@ deleteSketch = async (file) => {
 function getFilepaths(dir) {
   let files = [];
   fs.readdirSync(dir).forEach((file) => {
-    files.push(`${dir}/${file}`);
+    const path = `${dir}/${file}`;
+    if (fs.lstatSync(path).isDirectory()) {
+      files.push(path);
+    }
   });
   return files;
 }
@@ -311,7 +314,7 @@ async function main() {
   if (getSketchesRes.status != 200) {
     console.log(
       "🔴 Failed to get existing files. The server returned status code: " +
-        getFilesRes.status
+        getSketchesRes.status
     );
     process.exit(1);
   }


### PR DESCRIPTION
An error occurred while running `yarn upload-examples`:

```txt
Obtaining session ID...
🟢 Successfully obtained session ID.

Uploading sketches...
node:fs:1564
  const result = binding.readdir(
                         ^

Error: ENOTDIR: not a directory, scandir 'examples/README.md'
    at Object.readdirSync (node:fs:1564:26)
    at getFilepaths (/Users/subairui/Documents/projects/ml5-next-gen/scripts/uploadExamples.js:148:6)
    at recursiveAddFiles (/Users/subairui/Documents/projects/ml5-next-gen/scripts/uploadExamples.js:229:21)
    at createSketchObject (/Users/subairui/Documents/projects/ml5-next-gen/scripts/uploadExamples.js:260:3)
    at main (/Users/subairui/Documents/projects/ml5-next-gen/scripts/uploadExamples.js:332:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  errno: -20,
  code: 'ENOTDIR',
  syscall: 'scandir',
  path: 'examples/README.md'
}

Node.js v24.4.0
```

The existing code assumes that all paths under the examples directory are subdirectories. However, we recently added a new README file in examples (see [PR #251](https://github.com/ml5js/ml5-next-gen/pull/251)), which breaks that assumption. This PR updates the logic to filter out non-directory paths when uploading, ensuring compatibility with the new file structure.