### PR TITLE
Fix image classifier with teachable machine

### DIFF
--- a/src/ImageClassifier/index.js
+++ b/src/ImageClassifier/index.js
@@ -260,15 +260,16 @@ class ImageClassifier {
    * @return {function} a promise or the results of a given callback, cb.
    */
   async classifyStart(inputNumOrCallback, numOrCallback, cb) {
-    const { image, number, callback } = handleArguments(
-      inputNumOrCallback,
-      numOrCallback,
-      cb
-    ).require("image", "No input provided.");
-
     // Function to classify a single frame
     const classifyFrame = async () => {
+      const { image, number, callback } = handleArguments(
+        inputNumOrCallback,
+        numOrCallback,
+        cb
+      ).require("image", "No input provided.");
+
       await mediaReady(image, true);
+
       // call the callback function
       await callCallback(this.classifyInternal(image, number || this.topk), callback);
       


### PR DESCRIPTION
> fixes: https://github.com/ml5js/ml5-next-gen/issues/286

`imageClassifier.classifyStart` fails to detect the webcam when using a Teachable Machine model. It turns out that in this scenario, we need to process the input variable inside each detection loop.

I’m not entirely sure what’s going on with `this.model.predict`, but for now, it doesn’t seem to handle a video element as expected. What it **can** process correctly is a canvas element.

```js
async classifyInternal(imgToPredict, numberOfClasses) {
  // ...
  if (this.modelUrl) {
    await tf.nextFrame();
    const predictions = this.model.predict(imgToPredict);
  }
  // ...
  return results;
 }
```

If we process the input only once, it remains a video element. However, if we process the input inside the detection loop, it becomes a canvas element — which can be successfully handled by the model.