### PR TITLE
feat(models): add offline model caching via IndexedDB

### DIFF
--- a/examples/handPose-keypoints-offline/index.html
+++ b/examples/handPose-keypoints-offline/index.html
@@ -1,0 +1,50 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates offline-capable hand tracking using ml5.handPose
+  with the { cache: true } option. On first load the model is downloaded from
+  the network and saved to IndexedDB. On every subsequent load the model is
+  served from the local cache — no internet connection required.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ml5.js handPose Offline Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.10/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+      }
+      button {
+        margin: 5px;
+        padding: 5px 10px;
+      }
+      #status-bar {
+        margin: 10px 0;
+        padding: 10px;
+        background: #f0f0f0;
+        border-radius: 4px;
+        display: inline-block;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="controls">
+      <button id="btn-cache">Pre-Download Model</button>
+      <button id="btn-start">Start HandPose</button>
+      <button id="btn-clear">Clear Cache</button>
+    </div>
+
+    <div id="status-bar">Checking cache…</div>
+
+    <!-- p5.js appends the canvas here -->
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/handPose-keypoints-offline/sketch.js
+++ b/examples/handPose-keypoints-offline/sketch.js
@@ -1,0 +1,178 @@
+/*
+ * 👋 Hello! This is an ml5.js example made and shared with ❤️.
+ * Learn more about the ml5.js project: https://ml5js.org/
+ * ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ *
+ * Example: handPose — Offline / Cached Mode
+ *
+ * This sketch demonstrates how to use ml5.handPose with the { cache: true }
+ * option for offline-capable installations and exhibitions.
+ *
+ * How it works:
+ *   - First load (online):  the model downloads from the network and is
+ *     automatically saved to IndexedDB in your browser.
+ *   - Later loads (offline): the model loads directly from IndexedDB —
+ *     no internet connection needed.
+ *
+ * Three ways to interact with the cache:
+ *   ⬇  Pre-Download  — calls ml5.cacheModel("handPose") to cache the model
+ *                       *before* running the sketch, ideal for setup day.
+ *   ▶  Start HandPose — calls ml5.handPose({ cache: true }) to load the model
+ *                       (from cache if available, otherwise from network) and
+ *                       begin live hand tracking.
+ *   🗑  Clear Cache   — calls ml5.clearCache() to wipe all ml5 IndexedDB entries,
+ *                       useful for forcing a fresh download.
+ */
+
+let handPose;
+let video;
+let hands = [];
+
+// App state
+let isRunning = false;
+
+// DOM references
+const statusBar = document.getElementById("status-bar");
+const btnCache = document.getElementById("btn-cache");
+const btnStart = document.getElementById("btn-start");
+const btnClear = document.getElementById("btn-clear");
+
+// Check the initial cache status
+async function checkCacheStatus() {
+  setStatus("Checking IndexedDB cache…");
+  const cached = await ml5.isCached("handPose");
+  if (cached) {
+    setStatus("Model is cached — you can go offline and click Start HandPose.");
+  } else {
+    setStatus(
+      "Model not yet cached. Click Pre-Download to cache it, or Start HandPose to download and cache automatically."
+    );
+  }
+}
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the webcam capture but keep it hidden — we draw it to the canvas.
+  video = createCapture(VIDEO);
+  video.size(640, 480);
+  video.hide();
+
+  // Setup button callbacks
+  btnCache.addEventListener("click", onPreDownload);
+  btnStart.addEventListener("click", onStart);
+  btnClear.addEventListener("click", onClearCache);
+
+  checkCacheStatus();
+}
+
+function draw() {
+  if (isRunning) {
+    // Draw the webcam video
+    image(video, 0, 0, width, height);
+
+    // Draw all the tracked hand points
+    for (let i = 0; i < hands.length; i++) {
+      let hand = hands[i];
+      for (let j = 0; j < hand.keypoints.length; j++) {
+        let keypoint = hand.keypoints[j];
+        fill(0, 255, 0);
+        noStroke();
+        circle(keypoint.x, keypoint.y, 10);
+      }
+    }
+  } else {
+    // Idle state
+    background(200);
+    fill(100);
+    noStroke();
+    textSize(18);
+    textAlign(CENTER, CENTER);
+    text(
+      "Webcam will appear here after\nclicking Start HandPose",
+      width / 2,
+      height / 2
+    );
+  }
+}
+
+// Callback function for when handPose outputs data
+function gotHands(results) {
+  hands = results;
+}
+
+// ─── Button handlers ──────────────────────────────────────────────────────────
+
+async function onPreDownload() {
+  btnCache.disabled = true;
+  btnStart.disabled = true;
+
+  setStatus("Downloading HandPose models and saving to IndexedDB…");
+
+  try {
+    await ml5.cacheModel("handPose");
+    setStatus(
+      "Models cached successfully! You can now disconnect from the internet and use Start HandPose."
+    );
+  } catch (err) {
+    setStatus(`Download failed: ${err.message}`);
+  }
+
+  btnCache.disabled = false;
+  btnStart.disabled = false;
+}
+
+async function onStart() {
+  btnCache.disabled = true;
+  btnStart.disabled = true;
+
+  const cached = await ml5.isCached("handPose");
+  if (cached) {
+    setStatus("Loading HandPose from local cache…");
+  } else {
+    setStatus(
+      "Downloading HandPose models (first time — this may take a moment)…"
+    );
+  }
+
+  // Pass { cache: true } to load from cache or save to cache
+  handPose = await ml5.handPose({ cache: true });
+
+  const nowCached = await ml5.isCached("handPose");
+  setStatus(
+    nowCached
+      ? "Running — model loaded from cache. Safe to go offline!"
+      : "Running — model loaded from network (cache unavailable)."
+  );
+
+  isRunning = true;
+  handPose.detectStart(video, gotHands);
+
+  btnStart.textContent = "HandPose Running";
+  btnStart.disabled = true;
+  btnCache.disabled = false;
+}
+
+async function onClearCache() {
+  btnClear.disabled = true;
+
+  setStatus("Clearing ml5 model cache…");
+  const count = await ml5.clearCache();
+
+  if (count > 0) {
+    setStatus(
+      `Removed ${count} cached model file${
+        count !== 1 ? "s" : ""
+      } from IndexedDB.`
+    );
+  } else {
+    setStatus("Cache was already empty.");
+  }
+
+  btnClear.disabled = false;
+}
+
+function setStatus(message) {
+  if (statusBar) statusBar.textContent = message;
+  console.log("[handPose-offline]", message);
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
+    "@tensorflow/tfjs-node": "^4.22.0",
     "all-contributors-cli": "^6.26.1",
     "babel-jest": "^29.7.0",
     "bson-objectid": "^2.0.4",

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -27,6 +27,13 @@ import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import objectRenameKey from "../utils/objectRenameKey";
 import { isVideo } from "../utils/handleArguments";
+import { CachingIOHandler } from "../utils/modelCache";
+import {
+  getBodyPoseMoveNetUrl,
+  getBodyPoseMoveNetCacheKey,
+  getBodyPoseBlazePoseUrls,
+  getBodyPoseBlazePoseCacheKeys,
+} from "../utils/modelRegistry";
 
 /**
  * User provided options object for BodyPose with MoveNet model.
@@ -44,6 +51,9 @@ import { isVideo } from "../utils/handleArguments";
  * @property {string} [trackerType]           - The type of tracker to use.
  * @property {object} [trackerConfig]         - Advanced tracker configurations.
  * @property {string} [modelUrl]              - The file path or URL to the MoveNet model.
+ * @property {boolean} [cache]               - Whether to cache the model in IndexedDB for offline
+ *                                             use. On first load the model is downloaded and saved;
+ *                                             on subsequent loads it is served from the local cache.
  */
 
 /**
@@ -64,6 +74,9 @@ import { isVideo } from "../utils/handleArguments";
  *                                              model. Only for `tfjs` runtime.
  * @property {string} [landmarkModelUrl]      - The file path or URL to the BlazePose landmark
  *                                              model. Only for `tfjs` runtime.
+ * @property {boolean} [cache]               - Whether to cache the model in IndexedDB for offline
+ *                                             use. On first load the model is downloaded and saved;
+ *                                             on subsequent loads it is served from the local cache.
  */
 
 /**
@@ -227,6 +240,23 @@ class BodyPose {
         blazePoseConfigSchema,
         "bodyPose"
       );
+
+      // If cache: true is requested and runtime is tfjs, wrap the model URLs
+      // with CachingIOHandler for transparent IndexedDB caching.
+      if (this.userOptions?.cache === true && modelConfig.runtime === "tfjs") {
+        const defaults = getBodyPoseBlazePoseUrls(modelConfig);
+        const keys = getBodyPoseBlazePoseCacheKeys(modelConfig);
+        const detectorUrl = modelConfig.detectorModelUrl ?? defaults.detector;
+        const landmarkUrl = modelConfig.landmarkModelUrl ?? defaults.landmark;
+        modelConfig.detectorModelUrl = new CachingIOHandler(
+          detectorUrl,
+          keys.detector
+        );
+        modelConfig.landmarkModelUrl = new CachingIOHandler(
+          landmarkUrl,
+          keys.landmark
+        );
+      }
     } else {
       pipeline = poseDetection.SupportedModels.MoveNet;
       modelConfig = handleOptions(
@@ -234,6 +264,19 @@ class BodyPose {
         MoveNetConfigSchema,
         "bodyPose"
       );
+
+      // If cache: true is requested and no custom modelUrl is provided, wrap
+      // the default URL with CachingIOHandler for transparent IndexedDB caching.
+      // We read modelType as a string here, before the switch below replaces it
+      // with the poseDetection enum value.
+      if (this.userOptions?.cache === true && !modelConfig.modelUrl) {
+        const url = getBodyPoseMoveNetUrl({ modelType: modelConfig.modelType });
+        const key = getBodyPoseMoveNetCacheKey({
+          modelType: modelConfig.modelType,
+        });
+        modelConfig.modelUrl = new CachingIOHandler(url, key);
+      }
+
       // Map the modelType string to the `movenet.modelType` enum
       switch (modelConfig.modelType) {
         case "SINGLEPOSE_LIGHTNING":
@@ -277,6 +320,7 @@ class BodyPose {
     );
     const { image, callback } = argumentObject;
     // Run the detection
+    await this.ready;
     await mediaReady(image, false);
     const predictions = await this.model.estimatePoses(image);
     let result = predictions;
@@ -342,6 +386,7 @@ class BodyPose {
    * @private
    */
   async detectLoop() {
+    await this.ready;
     await mediaReady(this.detectMedia, false);
     while (!this.signalStop) {
       const predictions = await this.model.estimatePoses(this.detectMedia);

--- a/src/BodySegmentation/index.js
+++ b/src/BodySegmentation/index.js
@@ -208,6 +208,7 @@ class BodySegmentation {
     );
     const { image, callback } = argumentObject;
 
+    await this.ready;
     await mediaReady(image, false);
 
     let inputForSegmenter = image;
@@ -330,6 +331,7 @@ class BodySegmentation {
    * @private
    */
   async detectLoop() {
+    await this.ready;
     await mediaReady(this.detectMedia, false);
     while (!this.signalStop) {
       let inputForSegmenter = this.detectMedia;

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -26,6 +26,8 @@ import { mediaReady } from "../utils/imageUtilities";
 import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import { UV_COORDS } from "./uv_coords";
+import { CachingIOHandler } from "../utils/modelCache";
+import { getFaceMeshUrls, getFaceMeshCacheKeys } from "../utils/modelRegistry";
 
 /**
  * User provided options object for FaceMesh. See config schema below for default and available values.
@@ -40,6 +42,9 @@ import { UV_COORDS } from "./uv_coords";
  *                                           `tfjs` runtime.
  * @property {string} [landmarkModelUrl]   - The file path or URL to the landmark model. Only for
  *                                           `tfjs` runtime.
+ * @property {boolean} [cache]             - Whether to cache the model in IndexedDB for offline use.
+ *                                           On first load the model is downloaded and saved; on
+ *                                           subsequent loads it is served from the local cache.
  */
 
 /**
@@ -146,6 +151,26 @@ class FaceMesh {
 
     // Load the model once tfjs is ready
     await tf.ready();
+
+    // If cache: true is requested and runtime is tfjs, wrap the model URLs with
+    // CachingIOHandler so they are transparently loaded from IndexedDB (or
+    // downloaded and stored there on first use).
+    if (this.userOptions?.cache === true && modelConfig.runtime === "tfjs") {
+      const defaults = getFaceMeshUrls(modelConfig);
+      const keys = getFaceMeshCacheKeys(modelConfig);
+      // Use the user-provided URL if given, otherwise fall back to the default.
+      const detectorUrl = modelConfig.detectorModelUrl ?? defaults.detector;
+      const landmarkUrl = modelConfig.landmarkModelUrl ?? defaults.landmark;
+      modelConfig.detectorModelUrl = new CachingIOHandler(
+        detectorUrl,
+        keys.detector
+      );
+      modelConfig.landmarkModelUrl = new CachingIOHandler(
+        landmarkUrl,
+        keys.landmark
+      );
+    }
+
     this.model = await faceLandmarksDetection.createDetector(
       pipeline,
       modelConfig
@@ -170,6 +195,7 @@ class FaceMesh {
     );
     const { image, callback } = argumentObject;
     // Run the prediction
+    await this.ready;
     await mediaReady(image, false);
     const predictions = await this.model.estimateFaces(
       image,
@@ -230,6 +256,7 @@ class FaceMesh {
    * @private
    */
   async detectLoop() {
+    await this.ready;
     await mediaReady(this.detectMedia, false);
     while (!this.signalStop) {
       const predictions = await this.model.estimateFaces(

--- a/src/HandPose/index.js
+++ b/src/HandPose/index.js
@@ -27,6 +27,8 @@ import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import { mediaReady } from "../utils/imageUtilities";
 import objectRenameKey from "../utils/objectRenameKey";
+import { ensureCached } from "../utils/modelCache";
+import { getHandPoseUrls, getHandPoseCacheKeys } from "../utils/modelRegistry";
 
 /**
  * User provided options object for HandPose. See config schema below for default and available values.
@@ -41,6 +43,9 @@ import objectRenameKey from "../utils/objectRenameKey";
  *                                           for `tfjs` runtime.
  * @property {string} [landmarkModelUrl]   - The file path or URL to the hand landmark model. Only
  *                                           for `tfjs` runtime.
+ * @property {boolean} [cache]             - Whether to cache the model in IndexedDB for offline use.
+ *                                           On first load the model is downloaded and saved; on
+ *                                           subsequent loads it is served from the local cache.
  */
 
 /**
@@ -152,6 +157,25 @@ class HandPose {
 
     // Load the Tensorflow.js detector instance
     await tf.ready();
+
+    // If cache: true is requested and runtime is tfjs, pre-cache the models in
+    // IndexedDB and replace the URL strings with `indexeddb://` paths.
+    // Note: @tensorflow-models/hand-pose-detection only accepts string URLs,
+    // so we cannot inject an IOHandler object — instead we pre-cache the models
+    // and pass back the indexeddb:// string URLs.
+    if (this.userOptions?.cache === true && modelConfig.runtime === "tfjs") {
+      const defaults = getHandPoseUrls(modelConfig);
+      const keys = getHandPoseCacheKeys(modelConfig);
+      const detectorUrl = modelConfig.detectorModelUrl ?? defaults.detector;
+      const landmarkUrl = modelConfig.landmarkModelUrl ?? defaults.landmark;
+      const [cachedDetectorUrl, cachedLandmarkUrl] = await Promise.all([
+        ensureCached(detectorUrl, keys.detector),
+        ensureCached(landmarkUrl, keys.landmark),
+      ]);
+      modelConfig.detectorModelUrl = cachedDetectorUrl;
+      modelConfig.landmarkModelUrl = cachedLandmarkUrl;
+    }
+
     this.model = await handPoseDetection.createDetector(pipeline, modelConfig);
     return this;
   }
@@ -179,6 +203,7 @@ class HandPose {
     );
     const { image, callback } = argumentObject;
     // Run the detection
+    await this.ready;
     await mediaReady(image, false);
     const predictions = await this.model.estimateHands(
       image,
@@ -242,6 +267,7 @@ class HandPose {
    * @private
    */
   async detectLoop() {
+    await this.ready;
     await mediaReady(this.detectMedia, false);
     while (!this.signalStop) {
       const predictions = await this.model.estimateHands(

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,12 @@ import * as tf from "@tensorflow/tfjs";
 import * as tfvis from "@tensorflow/tfjs-vis";
 import p5Utils from "./utils/p5Utils";
 import packageInfo from "../package.json";
+import {
+  cacheModel,
+  clearCache,
+  listCachedModels,
+  isCached,
+} from "./utils/modelCache";
 
 const withPreload = {
   bodyPose,
@@ -25,7 +31,7 @@ const withPreload = {
   neuralNetwork,
   sentiment,
   soundClassifier,
-  objectDetection
+  objectDetection,
 };
 
 const withoutAsync = {
@@ -36,11 +42,19 @@ const ml5 = Object.assign({ p5Utils }, withPreload, {
   tf,
   tfvis,
   setBackend,
+  cacheModel,
+  clearCache,
+  listCachedModels,
+  isCached,
   version: packageInfo.version,
   setP5: p5Utils.setP5.bind(p5Utils),
 });
 
-p5Utils.setupP5Integration(ml5, Object.keys(withPreload), Object.keys(withoutAsync));
+p5Utils.setupP5Integration(
+  ml5,
+  Object.keys(withPreload),
+  Object.keys(withoutAsync)
+);
 
 communityStatement();
 

--- a/src/utils/modelCache.js
+++ b/src/utils/modelCache.js
@@ -1,0 +1,363 @@
+/**
+ * @license
+ * Copyright (c) 2020-2024 ml5
+ * This software is released under the ml5.js License.
+ * https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ */
+
+/**
+ * @file modelCache.js
+ *
+ * Offline caching infrastructure for ml5 models using IndexedDB.
+ *
+ * Two caching strategies are provided:
+ *
+ * 1. CachingIOHandler — a tf.io.IOHandler that transparently loads from
+ *    IndexedDB on cache hit, or from HTTP on cache miss (then saves to
+ *    IndexedDB). Used with models whose URL options accept an IOHandler
+ *    object (FaceMesh, BodyPose/MoveNet, BodyPose/BlazePose).
+ *
+ * 2. ensureCached() — pre-caches a model and returns an `indexeddb://`
+ *    string URL. Used with HandPose, which only accepts string URLs for
+ *    its detector/landmark options.
+ *
+ * Public ml5 API exported via src/index.js:
+ *   - ml5.cacheModel(name, options?) — pre-download a model to IndexedDB
+ *   - ml5.clearCache()               — remove all ml5 cached models
+ *   - ml5.listCachedModels()         — list all ml5 cached models
+ *   - ml5.isCached(name, options?)   — check if a model is cached
+ */
+
+import * as tf from "@tensorflow/tfjs";
+import {
+  ML5_CACHE_PREFIX,
+  getFaceMeshUrls,
+  getFaceMeshCacheKeys,
+  getHandPoseUrls,
+  getHandPoseCacheKeys,
+  getBodyPoseMoveNetUrl,
+  getBodyPoseMoveNetCacheKey,
+  getBodyPoseBlazePoseUrls,
+  getBodyPoseBlazePoseCacheKeys,
+} from "./modelRegistry";
+
+// ─── URL helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * The query string appended to TFHub base URLs to form a fetchable model.json URL.
+ * @private
+ */
+const TFHUB_SEARCH_PARAM = "model.json?tfjs-format=file";
+
+/**
+ * Transforms a canonical TFHub URL into its directly-fetchable form by
+ * appending `/model.json?tfjs-format=file`. Non-TFHub URLs are returned
+ * unchanged.
+ *
+ * This mirrors the internal transformation performed by tfjs-converter's
+ * `loadGraphModel`, which we must replicate when constructing our own HTTP
+ * handlers.
+ *
+ * @param {string} url - Original model URL.
+ * @returns {string} URL ready to be fetched.
+ * @private
+ */
+function toFetchUrl(url) {
+  if (url.includes("https://tfhub.dev") || url.includes("http://tfhub.dev")) {
+    const base = url.endsWith("/") ? url : url + "/";
+    return `${base}${TFHUB_SEARCH_PARAM}`;
+  }
+  return url;
+}
+
+// ─── CachingIOHandler ─────────────────────────────────────────────────────────
+
+/**
+ * A TensorFlow.js IO handler that caches model artifacts in IndexedDB.
+ *
+ * On `load()`:
+ *   1. Attempts to load from IndexedDB (cache hit → fast, offline).
+ *   2. On cache miss, fetches via HTTP (applying TFHub URL transformation).
+ *   3. Saves the downloaded artifacts to IndexedDB for future loads.
+ *
+ * Designed to be passed directly as a `modelUrl` / `detectorModelUrl` /
+ * `landmarkModelUrl` option to the `@tensorflow-models` packages that
+ * accept `string | tf.io.IOHandler`.
+ *
+ * @example
+ * const handler = new CachingIOHandler(
+ *   "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+ *   "ml5-cache-facemesh-detector"
+ * );
+ * const model = await tf.loadGraphModel(handler);
+ */
+export class CachingIOHandler {
+  /**
+   * @param {string} url      - Canonical model URL (TFHub or other HTTP URL).
+   * @param {string} cacheKey - IndexedDB key (without `indexeddb://` prefix).
+   */
+  constructor(url, cacheKey) {
+    this.url = url;
+    this.cacheKey = cacheKey;
+  }
+
+  /**
+   * Loads model artifacts from IndexedDB (if cached) or HTTP (with auto-save).
+   * @returns {Promise<tf.io.ModelArtifacts>}
+   */
+  async load() {
+    const idbPath = `indexeddb://${this.cacheKey}`;
+
+    // ── 1. Try IndexedDB cache ──────────────────────────────────────────────
+    try {
+      const loadHandlers = tf.io.getLoadHandlers(idbPath);
+      if (loadHandlers.length > 0) {
+        const artifacts = await loadHandlers[0].load();
+        if (artifacts) {
+          console.log(`🟩 ml5.js: Loaded model from cache (${this.cacheKey})`);
+          return artifacts;
+        }
+      }
+    } catch {
+      // Cache miss — fall through to HTTP fetch
+    }
+
+    // ── 2. Fetch from HTTP ──────────────────────────────────────────────────
+    console.log(`🟦 ml5.js: Downloading model (${this.cacheKey})…`);
+    const fetchUrl = toFetchUrl(this.url);
+    const httpHandler = tf.io.http(fetchUrl);
+    const artifacts = await httpHandler.load();
+
+    // ── 3. Save to IndexedDB ────────────────────────────────────────────────
+    try {
+      const saveHandlers = tf.io.getSaveHandlers(idbPath);
+      if (saveHandlers.length > 0) {
+        await saveHandlers[0].save(artifacts);
+        console.log(`🟩 ml5.js: Model cached to IndexedDB (${this.cacheKey})`);
+      }
+    } catch (err) {
+      console.warn(
+        `🟪 ml5.js: Could not cache model to IndexedDB (${this.cacheKey}): ${err.message}`
+      );
+      // Non-fatal — model was loaded successfully from HTTP, just not persisted
+    }
+
+    return artifacts;
+  }
+}
+
+// ─── ensureCached ─────────────────────────────────────────────────────────────
+
+/**
+ * Ensures a model is saved in IndexedDB and returns its `indexeddb://` URL.
+ *
+ * Used for models like HandPose that only accept *string* URLs (not IOHandler
+ * objects). Call this before `createDetector` to pre-warm the cache, then pass
+ * the returned `indexeddb://` URL as the model URL string.
+ *
+ * If the model is already cached the download is skipped.
+ *
+ * @param {string} url      - Canonical model URL (TFHub or other HTTP URL).
+ * @param {string} cacheKey - IndexedDB key (without `indexeddb://` prefix).
+ * @returns {Promise<string>} The `indexeddb://cacheKey` URL if caching
+ *   succeeded, otherwise the original HTTP URL as a fallback.
+ */
+export async function ensureCached(url, cacheKey) {
+  const idbPath = `indexeddb://${cacheKey}`;
+
+  // ── Check if already cached ─────────────────────────────────────────────
+  try {
+    const models = await tf.io.listModels();
+    if (idbPath in models) {
+      console.log(`🟩 ml5.js: Model already cached (${cacheKey})`);
+      return idbPath;
+    }
+  } catch {
+    // listModels is not critical — proceed to fetch
+  }
+
+  // ── Fetch and cache ─────────────────────────────────────────────────────
+  console.log(`🟦 ml5.js: Downloading model (${cacheKey})…`);
+  const fetchUrl = toFetchUrl(url);
+
+  try {
+    const httpHandler = tf.io.http(fetchUrl);
+    const artifacts = await httpHandler.load();
+
+    const saveHandlers = tf.io.getSaveHandlers(idbPath);
+    if (saveHandlers.length > 0) {
+      await saveHandlers[0].save(artifacts);
+      console.log(`🟩 ml5.js: Model cached to IndexedDB (${cacheKey})`);
+      return idbPath;
+    } else {
+      console.warn(
+        `🟪 ml5.js: No IndexedDB save handler found for (${cacheKey}). Falling back to HTTP.`
+      );
+      return fetchUrl;
+    }
+  } catch (err) {
+    console.warn(
+      `🟪 ml5.js: Could not cache model (${cacheKey}): ${err.message}. ` +
+        `Falling back to HTTP.`
+    );
+    // Return the fetch URL as a fallback so the model still loads
+    return fetchUrl;
+  }
+}
+
+// ─── Public cache management API ─────────────────────────────────────────────
+
+/**
+ * Pre-downloads and caches a named ml5 model to IndexedDB.
+ *
+ * Subsequent calls to `ml5.faceMesh({ cache: true })` (or equivalent) will
+ * load from the local cache without any network requests.
+ *
+ * @param {"faceMesh"|"handPose"|"bodyPose"|"bodyPose-BlazePose"} modelName
+ *   Friendly model name (case-insensitive).
+ * @param {object} [options]
+ *   Same options you would pass to the model constructor (e.g.
+ *   `{ refineLandmarks: true }`, `{ modelType: "lite" }`). Used to select
+ *   the correct variant to cache. Defaults match each model's defaults.
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // Cache default FaceMesh before going offline
+ * await ml5.cacheModel("faceMesh");
+ *
+ * // Cache the attention-mesh variant
+ * await ml5.cacheModel("faceMesh", { refineLandmarks: true });
+ *
+ * // Cache HandPose lite variant
+ * await ml5.cacheModel("handPose", { modelType: "lite" });
+ *
+ * // Cache BlazePose
+ * await ml5.cacheModel("bodyPose-BlazePose", { modelType: "full" });
+ */
+export async function cacheModel(modelName, options = {}) {
+  const name = modelName.toLowerCase().replace(/[-_\s]/g, "");
+
+  if (name === "facemesh") {
+    const urls = getFaceMeshUrls(options);
+    const keys = getFaceMeshCacheKeys(options);
+    await Promise.all([
+      ensureCached(urls.detector, keys.detector),
+      ensureCached(urls.landmark, keys.landmark),
+    ]);
+  } else if (name === "handpose") {
+    const urls = getHandPoseUrls(options);
+    const keys = getHandPoseCacheKeys(options);
+    await Promise.all([
+      ensureCached(urls.detector, keys.detector),
+      ensureCached(urls.landmark, keys.landmark),
+    ]);
+  } else if (name === "bodypose" || name === "bodyposemovenet") {
+    // Default bodyPose is MoveNet
+    const url = getBodyPoseMoveNetUrl(options);
+    const key = getBodyPoseMoveNetCacheKey(options);
+    await ensureCached(url, key);
+  } else if (name === "bodyposeblazepose" || name === "blazepose") {
+    const urls = getBodyPoseBlazePoseUrls(options);
+    const keys = getBodyPoseBlazePoseCacheKeys(options);
+    await Promise.all([
+      ensureCached(urls.detector, keys.detector),
+      ensureCached(urls.landmark, keys.landmark),
+    ]);
+  } else {
+    throw new Error(
+      `🟪 ml5.js: Unknown model name '${modelName}' for cacheModel(). ` +
+        `Valid names: 'faceMesh', 'handPose', 'bodyPose', 'bodyPose-BlazePose'.`
+    );
+  }
+}
+
+/**
+ * Returns a map of all ml5 model artifacts currently stored in IndexedDB.
+ *
+ * Keys are full `indexeddb://` URLs; values are `ModelArtifactsInfo` objects
+ * from TensorFlow.js (contain `dateSaved`, `modelTopologyBytes`, etc.).
+ *
+ * @returns {Promise<Object.<string, tf.io.ModelArtifactsInfo>>}
+ *
+ * @example
+ * const cached = await ml5.listCachedModels();
+ * console.log(Object.keys(cached));
+ * // → ["indexeddb://ml5-cache-facemesh-detector", ...]
+ */
+export async function listCachedModels() {
+  const allModels = await tf.io.listModels();
+  const ml5Models = {};
+  for (const [key, info] of Object.entries(allModels)) {
+    if (key.startsWith(`indexeddb://${ML5_CACHE_PREFIX}`)) {
+      ml5Models[key] = info;
+    }
+  }
+  return ml5Models;
+}
+
+/**
+ * Removes all ml5 model artifacts from IndexedDB.
+ *
+ * @returns {Promise<number>} The number of models removed.
+ *
+ * @example
+ * const removed = await ml5.clearCache();
+ * console.log(`Removed ${removed} cached model(s).`);
+ */
+export async function clearCache() {
+  const allModels = await tf.io.listModels();
+  const ml5Keys = Object.keys(allModels).filter((k) =>
+    k.startsWith(`indexeddb://${ML5_CACHE_PREFIX}`)
+  );
+  await Promise.all(ml5Keys.map((k) => tf.io.removeModel(k)));
+  if (ml5Keys.length > 0) {
+    console.log(`🟩 ml5.js: Cleared ${ml5Keys.length} cached model(s).`);
+  }
+  return ml5Keys.length;
+}
+
+/**
+ * Checks whether a specific ml5 model variant is currently cached in IndexedDB.
+ *
+ * @param {"faceMesh"|"handPose"|"bodyPose"|"bodyPose-BlazePose"} modelName
+ *   Friendly model name (case-insensitive).
+ * @param {object} [options]
+ *   Options matching those passed to the model constructor. Used to select
+ *   the correct variant. Defaults match each model's defaults.
+ * @returns {Promise<boolean>}
+ *
+ * @example
+ * if (await ml5.isCached("faceMesh")) {
+ *   console.log("FaceMesh is ready for offline use!");
+ * }
+ */
+export async function isCached(modelName, options = {}) {
+  let keys;
+  const name = modelName.toLowerCase().replace(/[-_\s]/g, "");
+
+  if (name === "facemesh") {
+    keys = getFaceMeshCacheKeys(options);
+  } else if (name === "handpose") {
+    keys = getHandPoseCacheKeys(options);
+  } else if (name === "bodypose" || name === "bodyposemovenet") {
+    const key = getBodyPoseMoveNetCacheKey(options);
+    keys = { main: key };
+  } else if (name === "bodyposeblazepose" || name === "blazepose") {
+    keys = getBodyPoseBlazePoseCacheKeys(options);
+  } else {
+    throw new Error(
+      `🟪 ml5.js: Unknown model name '${modelName}' for isCached(). ` +
+        `Valid names: 'faceMesh', 'handPose', 'bodyPose', 'bodyPose-BlazePose'.`
+    );
+  }
+
+  let allModels;
+  try {
+    allModels = await tf.io.listModels();
+  } catch {
+    return false;
+  }
+
+  // All model parts must be cached for the model to be considered "cached"
+  return Object.values(keys).every((key) => `indexeddb://${key}` in allModels);
+}

--- a/src/utils/modelRegistry.js
+++ b/src/utils/modelRegistry.js
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright (c) 2020-2024 ml5
+ * This software is released under the ml5.js License.
+ * https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+ */
+
+/**
+ * @file modelRegistry.js
+ *
+ * Central registry of default model URLs and cache key generation for ml5 models.
+ * Used by the offline caching system to map model names and options to their
+ * canonical TFHub URLs and deterministic IndexedDB cache keys.
+ */
+
+/** Prefix for all ml5 model cache entries in IndexedDB. */
+export const ML5_CACHE_PREFIX = "ml5-cache";
+
+/**
+ * Canonical default TFHub URLs for all supported models.
+ * @private
+ */
+const MODEL_URLS = {
+  // FaceMesh
+  FACEMESH_DETECTOR:
+    "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+  FACEMESH_LANDMARK_MESH:
+    "https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1",
+  FACEMESH_LANDMARK_ATTENTION:
+    "https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/attention_mesh/1",
+
+  // HandPose
+  HANDPOSE_DETECTOR_FULL:
+    "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1",
+  HANDPOSE_DETECTOR_LITE:
+    "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/lite/1",
+  HANDPOSE_LANDMARK_FULL:
+    "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1",
+  HANDPOSE_LANDMARK_LITE:
+    "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/lite/1",
+
+  // BodyPose — MoveNet
+  MOVENET_SINGLEPOSE_LIGHTNING:
+    "https://tfhub.dev/google/tfjs-model/movenet/singlepose/lightning/4",
+  MOVENET_SINGLEPOSE_THUNDER:
+    "https://tfhub.dev/google/tfjs-model/movenet/singlepose/thunder/4",
+  MOVENET_MULTIPOSE_LIGHTNING:
+    "https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1",
+
+  // BodyPose — BlazePose
+  BLAZEPOSE_DETECTOR:
+    "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1",
+  BLAZEPOSE_LANDMARK_LITE:
+    "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/lite/2",
+  BLAZEPOSE_LANDMARK_FULL:
+    "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2",
+  BLAZEPOSE_LANDMARK_HEAVY:
+    "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/heavy/2",
+};
+
+// ─── FaceMesh ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the default model URLs for FaceMesh.
+ * @param {{ refineLandmarks?: boolean }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getFaceMeshUrls(options = {}) {
+  const refineLandmarks = options.refineLandmarks ?? false;
+  return {
+    detector: MODEL_URLS.FACEMESH_DETECTOR,
+    landmark: refineLandmarks
+      ? MODEL_URLS.FACEMESH_LANDMARK_ATTENTION
+      : MODEL_URLS.FACEMESH_LANDMARK_MESH,
+  };
+}
+
+/**
+ * Returns the IndexedDB cache keys for FaceMesh models.
+ * @param {{ refineLandmarks?: boolean }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getFaceMeshCacheKeys(options = {}) {
+  const refineLandmarks = options.refineLandmarks ?? false;
+  return {
+    detector: `${ML5_CACHE_PREFIX}-facemesh-detector`,
+    landmark: refineLandmarks
+      ? `${ML5_CACHE_PREFIX}-facemesh-landmark-attention`
+      : `${ML5_CACHE_PREFIX}-facemesh-landmark-mesh`,
+  };
+}
+
+// ─── HandPose ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the default model URLs for HandPose.
+ * @param {{ modelType?: "full" | "lite" }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getHandPoseUrls(options = {}) {
+  const modelType = options.modelType ?? "full";
+  return {
+    detector:
+      modelType === "lite"
+        ? MODEL_URLS.HANDPOSE_DETECTOR_LITE
+        : MODEL_URLS.HANDPOSE_DETECTOR_FULL,
+    landmark:
+      modelType === "lite"
+        ? MODEL_URLS.HANDPOSE_LANDMARK_LITE
+        : MODEL_URLS.HANDPOSE_LANDMARK_FULL,
+  };
+}
+
+/**
+ * Returns the IndexedDB cache keys for HandPose models.
+ * @param {{ modelType?: "full" | "lite" }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getHandPoseCacheKeys(options = {}) {
+  const modelType = options.modelType ?? "full";
+  return {
+    detector: `${ML5_CACHE_PREFIX}-handpose-detector-${modelType}`,
+    landmark: `${ML5_CACHE_PREFIX}-handpose-landmark-${modelType}`,
+  };
+}
+
+// ─── BodyPose — MoveNet ──────────────────────────────────────────────────────
+
+/**
+ * Returns the default model URL for BodyPose/MoveNet.
+ * @param {{ modelType?: string }} [options]
+ * @returns {string}
+ */
+export function getBodyPoseMoveNetUrl(options = {}) {
+  const modelType = options.modelType ?? "MULTIPOSE_LIGHTNING";
+  return MODEL_URLS[`MOVENET_${modelType.toUpperCase()}`];
+}
+
+/**
+ * Returns the IndexedDB cache key for BodyPose/MoveNet.
+ * @param {{ modelType?: string }} [options]
+ * @returns {string}
+ */
+export function getBodyPoseMoveNetCacheKey(options = {}) {
+  const modelType = options.modelType ?? "MULTIPOSE_LIGHTNING";
+  return `${ML5_CACHE_PREFIX}-bodypose-movenet-${modelType
+    .toLowerCase()
+    .replace(/_/g, "-")}`;
+}
+
+// ─── BodyPose — BlazePose ────────────────────────────────────────────────────
+
+/**
+ * Returns the default model URLs for BodyPose/BlazePose.
+ * @param {{ modelType?: "lite" | "full" | "heavy" }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getBodyPoseBlazePoseUrls(options = {}) {
+  const modelType = options.modelType ?? "full";
+  return {
+    detector: MODEL_URLS.BLAZEPOSE_DETECTOR,
+    landmark: MODEL_URLS[`BLAZEPOSE_LANDMARK_${modelType.toUpperCase()}`],
+  };
+}
+
+/**
+ * Returns the IndexedDB cache keys for BodyPose/BlazePose models.
+ * @param {{ modelType?: "lite" | "full" | "heavy" }} [options]
+ * @returns {{ detector: string, landmark: string }}
+ */
+export function getBodyPoseBlazePoseCacheKeys(options = {}) {
+  const modelType = options.modelType ?? "full";
+  return {
+    detector: `${ML5_CACHE_PREFIX}-bodypose-blazepose-detector`,
+    landmark: `${ML5_CACHE_PREFIX}-bodypose-blazepose-landmark-${modelType}`,
+  };
+}

--- a/tests/unit/modelCache.test.js
+++ b/tests/unit/modelCache.test.js
@@ -1,0 +1,561 @@
+/**
+ * Tests for modelCache.js
+ *
+ * All tf.io interactions are mocked so these tests run entirely in-process
+ * with no network requests and no IndexedDB access.
+ *
+ * Strategy:
+ *  - jest.mock("@tensorflow/tfjs") replaces the whole tf namespace.
+ *  - Each test configures the mock return values for the specific scenario
+ *    under test (cache hit, cache miss, IndexedDB save failure, etc.).
+ */
+
+// ── Mock @tensorflow/tfjs before any imports ─────────────────────────────────
+jest.mock("@tensorflow/tfjs", () => {
+  // Minimal stub — each test configures the functions it needs.
+  return {
+    io: {
+      getLoadHandlers: jest.fn(),
+      getSaveHandlers: jest.fn(),
+      http: jest.fn(),
+      listModels: jest.fn(),
+      removeModel: jest.fn(),
+    },
+  };
+});
+
+import * as tf from "@tensorflow/tfjs";
+import {
+  CachingIOHandler,
+  ensureCached,
+  cacheModel,
+  listCachedModels,
+  clearCache,
+  isCached,
+} from "../../src/utils/modelCache";
+import { ML5_CACHE_PREFIX } from "../../src/utils/modelRegistry";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Minimal fake artifacts object returned by load handlers. */
+const FAKE_ARTIFACTS = { modelTopology: {}, weightData: new ArrayBuffer(8) };
+
+/** Build a fake IndexedDB load handler that succeeds. */
+function makeIdbLoadHandler(artifacts = FAKE_ARTIFACTS) {
+  return { load: jest.fn().mockResolvedValue(artifacts) };
+}
+
+/** Build a fake IndexedDB save handler that succeeds. */
+function makeIdbSaveHandler() {
+  return { save: jest.fn().mockResolvedValue(undefined) };
+}
+
+/** Build a fake HTTP handler that succeeds. */
+function makeHttpHandler(artifacts = FAKE_ARTIFACTS) {
+  return { load: jest.fn().mockResolvedValue(artifacts) };
+}
+
+// ── CachingIOHandler ──────────────────────────────────────────────────────────
+
+describe("CachingIOHandler", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("cache hit — loads from IndexedDB, skips HTTP", () => {
+    it("returns the cached artifacts", async () => {
+      const idbHandler = makeIdbLoadHandler();
+      tf.io.getLoadHandlers.mockReturnValue([idbHandler]);
+
+      const handler = new CachingIOHandler(
+        "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+        "ml5-cache-facemesh-detector"
+      );
+      const artifacts = await handler.load();
+
+      expect(artifacts).toBe(FAKE_ARTIFACTS);
+      expect(idbHandler.load).toHaveBeenCalledTimes(1);
+      expect(tf.io.http).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cache miss — fetches from HTTP, then saves to IndexedDB", () => {
+    it("returns the HTTP artifacts", async () => {
+      // IndexedDB load throws → cache miss
+      tf.io.getLoadHandlers.mockReturnValue([
+        { load: jest.fn().mockRejectedValue(new Error("not found")) },
+      ]);
+
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+
+      const idbSaveHandler = makeIdbSaveHandler();
+      tf.io.getSaveHandlers.mockReturnValue([idbSaveHandler]);
+
+      const handler = new CachingIOHandler(
+        "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+        "ml5-cache-facemesh-detector"
+      );
+      const artifacts = await handler.load();
+
+      expect(artifacts).toBe(FAKE_ARTIFACTS);
+      expect(httpHandler.load).toHaveBeenCalledTimes(1);
+    });
+
+    it("saves the downloaded artifacts to IndexedDB", async () => {
+      tf.io.getLoadHandlers.mockReturnValue([
+        { load: jest.fn().mockRejectedValue(new Error("not found")) },
+      ]);
+
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+
+      const idbSaveHandler = makeIdbSaveHandler();
+      tf.io.getSaveHandlers.mockReturnValue([idbSaveHandler]);
+
+      const handler = new CachingIOHandler(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+      await handler.load();
+
+      expect(idbSaveHandler.save).toHaveBeenCalledWith(FAKE_ARTIFACTS);
+    });
+
+    it("appends TFHub search param for TFHub URLs", async () => {
+      tf.io.getLoadHandlers.mockReturnValue([
+        { load: jest.fn().mockRejectedValue(new Error("miss")) },
+      ]);
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+      tf.io.getSaveHandlers.mockReturnValue([makeIdbSaveHandler()]);
+
+      const handler = new CachingIOHandler(
+        "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+        "ml5-cache-facemesh-detector"
+      );
+      await handler.load();
+
+      const fetchedUrl = tf.io.http.mock.calls[0][0];
+      expect(fetchedUrl).toContain("model.json?tfjs-format=file");
+    });
+
+    it("does NOT append TFHub param for non-TFHub URLs", async () => {
+      tf.io.getLoadHandlers.mockReturnValue([
+        { load: jest.fn().mockRejectedValue(new Error("miss")) },
+      ]);
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+      tf.io.getSaveHandlers.mockReturnValue([makeIdbSaveHandler()]);
+
+      const handler = new CachingIOHandler(
+        "https://example.com/model/model.json",
+        "ml5-cache-custom"
+      );
+      await handler.load();
+
+      const fetchedUrl = tf.io.http.mock.calls[0][0];
+      expect(fetchedUrl).toBe("https://example.com/model/model.json");
+    });
+  });
+
+  describe("IndexedDB save failure is non-fatal", () => {
+    it("still returns the HTTP artifacts when save throws", async () => {
+      tf.io.getLoadHandlers.mockReturnValue([
+        { load: jest.fn().mockRejectedValue(new Error("miss")) },
+      ]);
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+
+      // Save handler throws
+      tf.io.getSaveHandlers.mockReturnValue([
+        { save: jest.fn().mockRejectedValue(new Error("quota exceeded")) },
+      ]);
+
+      const handler = new CachingIOHandler(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+
+      // Should NOT throw
+      await expect(handler.load()).resolves.toBe(FAKE_ARTIFACTS);
+    });
+  });
+
+  describe("no IndexedDB load handler available → falls back to HTTP", () => {
+    it("fetches via HTTP when getLoadHandlers returns empty array", async () => {
+      tf.io.getLoadHandlers.mockReturnValue([]); // No IDB handler available
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+      tf.io.getSaveHandlers.mockReturnValue([makeIdbSaveHandler()]);
+
+      const handler = new CachingIOHandler(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+      const artifacts = await handler.load();
+
+      expect(artifacts).toBe(FAKE_ARTIFACTS);
+      expect(httpHandler.load).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+// ── ensureCached ──────────────────────────────────────────────────────────────
+
+describe("ensureCached", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("already cached", () => {
+    it("returns the indexeddb:// URL without fetching", async () => {
+      tf.io.listModels.mockResolvedValue({
+        "indexeddb://ml5-cache-test": { dateSaved: new Date() },
+      });
+
+      const result = await ensureCached(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+
+      expect(result).toBe("indexeddb://ml5-cache-test");
+      expect(tf.io.http).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("not yet cached", () => {
+    it("downloads via HTTP, saves to IndexedDB, returns indexeddb:// URL", async () => {
+      tf.io.listModels.mockResolvedValue({}); // empty — not cached
+
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+
+      const idbSaveHandler = makeIdbSaveHandler();
+      tf.io.getSaveHandlers.mockReturnValue([idbSaveHandler]);
+
+      const result = await ensureCached(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+
+      expect(httpHandler.load).toHaveBeenCalledTimes(1);
+      expect(idbSaveHandler.save).toHaveBeenCalledWith(FAKE_ARTIFACTS);
+      expect(result).toBe("indexeddb://ml5-cache-test");
+    });
+
+    it("falls back to the HTTP URL when no save handler is available", async () => {
+      tf.io.listModels.mockResolvedValue({});
+
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+      tf.io.getSaveHandlers.mockReturnValue([]); // No IDB
+
+      const result = await ensureCached(
+        "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+        "ml5-cache-test"
+      );
+
+      // Falls back to the fetch URL (includes TFHub param)
+      expect(result).toContain("model.json?tfjs-format=file");
+    });
+
+    it("falls back to the HTTP URL when save throws", async () => {
+      tf.io.listModels.mockResolvedValue({});
+
+      const httpHandler = makeHttpHandler();
+      tf.io.http.mockReturnValue(httpHandler);
+      tf.io.getSaveHandlers.mockReturnValue([
+        { save: jest.fn().mockRejectedValue(new Error("quota exceeded")) },
+      ]);
+
+      // Should not throw
+      const result = await ensureCached(
+        "https://example.com/model",
+        "ml5-cache-test"
+      );
+      expect(typeof result).toBe("string");
+    });
+  });
+});
+
+// ── listCachedModels ──────────────────────────────────────────────────────────
+
+describe("listCachedModels", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("returns only ml5 entries from tf.io.listModels()", async () => {
+    tf.io.listModels.mockResolvedValue({
+      [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {
+        dateSaved: new Date(),
+      },
+      [`indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-full`]: {
+        dateSaved: new Date(),
+      },
+      "indexeddb://some-other-app-model": { dateSaved: new Date() },
+      "localstorage://other": { dateSaved: new Date() },
+    });
+
+    const result = await listCachedModels();
+
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result).toHaveProperty(
+      `indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`
+    );
+    expect(result).toHaveProperty(
+      `indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-full`
+    );
+    expect(result).not.toHaveProperty("indexeddb://some-other-app-model");
+  });
+
+  it("returns an empty object when no ml5 models are cached", async () => {
+    tf.io.listModels.mockResolvedValue({
+      "indexeddb://other-app-model": { dateSaved: new Date() },
+    });
+
+    const result = await listCachedModels();
+    expect(result).toEqual({});
+  });
+
+  it("returns an empty object when IndexedDB is empty", async () => {
+    tf.io.listModels.mockResolvedValue({});
+    const result = await listCachedModels();
+    expect(result).toEqual({});
+  });
+});
+
+// ── clearCache ────────────────────────────────────────────────────────────────
+
+describe("clearCache", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("removes all ml5 entries and returns the count", async () => {
+    tf.io.listModels.mockResolvedValue({
+      [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+      [`indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-full`]: {},
+      "indexeddb://unrelated-model": {},
+    });
+    tf.io.removeModel.mockResolvedValue(undefined);
+
+    const count = await clearCache();
+
+    expect(count).toBe(2);
+    // removeModel should have been called exactly for the two ml5 entries
+    expect(tf.io.removeModel).toHaveBeenCalledTimes(2);
+    expect(tf.io.removeModel).toHaveBeenCalledWith(
+      `indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`
+    );
+    expect(tf.io.removeModel).toHaveBeenCalledWith(
+      `indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-full`
+    );
+    // Non-ml5 entry must NOT be removed
+    expect(tf.io.removeModel).not.toHaveBeenCalledWith(
+      "indexeddb://unrelated-model"
+    );
+  });
+
+  it("returns 0 when there are no ml5 entries to clear", async () => {
+    tf.io.listModels.mockResolvedValue({
+      "indexeddb://unrelated-model": {},
+    });
+    tf.io.removeModel.mockResolvedValue(undefined);
+
+    const count = await clearCache();
+
+    expect(count).toBe(0);
+    expect(tf.io.removeModel).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 when IndexedDB is empty", async () => {
+    tf.io.listModels.mockResolvedValue({});
+    const count = await clearCache();
+    expect(count).toBe(0);
+  });
+});
+
+// ── isCached ──────────────────────────────────────────────────────────────────
+
+describe("isCached", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("faceMesh", () => {
+    it("returns true when both detector and landmark are cached", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-landmark-mesh`]: {},
+      });
+      await expect(isCached("faceMesh")).resolves.toBe(true);
+    });
+
+    it("returns false when only detector is cached", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+      });
+      await expect(isCached("faceMesh")).resolves.toBe(false);
+    });
+
+    it("returns true for the attention variant when both parts are cached", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-landmark-attention`]: {},
+      });
+      await expect(
+        isCached("faceMesh", { refineLandmarks: true })
+      ).resolves.toBe(true);
+    });
+  });
+
+  describe("handPose", () => {
+    it("returns true when both detector and landmark are cached (full)", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-full`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-handpose-landmark-full`]: {},
+      });
+      await expect(isCached("handPose")).resolves.toBe(true);
+    });
+
+    it("returns true for the lite variant", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-handpose-detector-lite`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-handpose-landmark-lite`]: {},
+      });
+      await expect(isCached("handPose", { modelType: "lite" })).resolves.toBe(
+        true
+      );
+    });
+
+    it("returns false when nothing is cached", async () => {
+      tf.io.listModels.mockResolvedValue({});
+      await expect(isCached("handPose")).resolves.toBe(false);
+    });
+  });
+
+  describe("bodyPose (MoveNet)", () => {
+    it("returns true when the MoveNet model is cached", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-bodypose-movenet-multipose-lightning`]:
+          {},
+      });
+      await expect(isCached("bodyPose")).resolves.toBe(true);
+    });
+
+    it("returns false when MoveNet is not cached", async () => {
+      tf.io.listModels.mockResolvedValue({});
+      await expect(isCached("bodyPose")).resolves.toBe(false);
+    });
+  });
+
+  describe("bodyPose-BlazePose", () => {
+    it("returns true when both detector and landmark are cached (full)", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-bodypose-blazepose-detector`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-bodypose-blazepose-landmark-full`]:
+          {},
+      });
+      await expect(isCached("bodyPose-BlazePose")).resolves.toBe(true);
+    });
+
+    it("returns false when only the detector is cached", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-bodypose-blazepose-detector`]: {},
+      });
+      await expect(isCached("bodyPose-BlazePose")).resolves.toBe(false);
+    });
+  });
+
+  describe("case-insensitivity and name normalization", () => {
+    it("accepts 'FACEMESH' (uppercase)", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-landmark-mesh`]: {},
+      });
+      await expect(isCached("FACEMESH")).resolves.toBe(true);
+    });
+
+    it("accepts 'face-mesh' (hyphenated)", async () => {
+      tf.io.listModels.mockResolvedValue({
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-detector`]: {},
+        [`indexeddb://${ML5_CACHE_PREFIX}-facemesh-landmark-mesh`]: {},
+      });
+      await expect(isCached("face-mesh")).resolves.toBe(true);
+    });
+  });
+
+  describe("returns false (not throws) when tf.io.listModels fails", () => {
+    it("returns false if listModels rejects", async () => {
+      tf.io.listModels.mockRejectedValue(new Error("IndexedDB unavailable"));
+      await expect(isCached("faceMesh")).resolves.toBe(false);
+    });
+  });
+
+  describe("unknown model name", () => {
+    it("throws for an unknown model name", async () => {
+      await expect(isCached("unknownModel")).rejects.toThrow(
+        /Unknown model name/i
+      );
+    });
+  });
+});
+
+// ── cacheModel ────────────────────────────────────────────────────────────────
+
+describe("cacheModel", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // For cacheModel we just verify that ensureCached-like behaviour is triggered
+  // (http handler is called) for each model family.
+  function setupForDownload() {
+    tf.io.listModels.mockResolvedValue({}); // nothing cached yet
+    const httpHandler = makeHttpHandler();
+    tf.io.http.mockReturnValue(httpHandler);
+    tf.io.getSaveHandlers.mockReturnValue([makeIdbSaveHandler()]);
+    return httpHandler;
+  }
+
+  it("calls tf.io.http for faceMesh (2 models)", async () => {
+    const httpHandler = setupForDownload();
+    await cacheModel("faceMesh");
+    // detector + landmark
+    expect(httpHandler.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls tf.io.http for handPose (2 models)", async () => {
+    const httpHandler = setupForDownload();
+    await cacheModel("handPose");
+    expect(httpHandler.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls tf.io.http for bodyPose/MoveNet (1 model)", async () => {
+    const httpHandler = setupForDownload();
+    await cacheModel("bodyPose");
+    expect(httpHandler.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls tf.io.http for bodyPose-BlazePose (2 models)", async () => {
+    const httpHandler = setupForDownload();
+    await cacheModel("bodyPose-BlazePose");
+    expect(httpHandler.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("is case-insensitive for the model name", async () => {
+    const httpHandler = setupForDownload();
+    await cacheModel("HANDPOSE");
+    expect(httpHandler.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips already-cached models (uses indexeddb URL instead of http)", async () => {
+    // Both HandPose models already in cache
+    tf.io.listModels.mockResolvedValue({
+      "indexeddb://ml5-cache-handpose-detector-full": {},
+      "indexeddb://ml5-cache-handpose-landmark-full": {},
+    });
+    tf.io.http.mockReturnValue(makeHttpHandler());
+
+    await cacheModel("handPose");
+
+    // Already cached → no HTTP downloads needed
+    expect(tf.io.http).not.toHaveBeenCalled();
+  });
+
+  it("throws for an unknown model name", async () => {
+    await expect(cacheModel("unknownModel")).rejects.toThrow(
+      /Unknown model name/i
+    );
+  });
+});

--- a/tests/unit/modelRegistry.test.js
+++ b/tests/unit/modelRegistry.test.js
@@ -1,0 +1,295 @@
+import {
+  ML5_CACHE_PREFIX,
+  getFaceMeshUrls,
+  getFaceMeshCacheKeys,
+  getHandPoseUrls,
+  getHandPoseCacheKeys,
+  getBodyPoseMoveNetUrl,
+  getBodyPoseMoveNetCacheKey,
+  getBodyPoseBlazePoseUrls,
+  getBodyPoseBlazePoseCacheKeys,
+} from "../../src/utils/modelRegistry";
+
+describe("modelRegistry", () => {
+  // ── ML5_CACHE_PREFIX ────────────────────────────────────────────────────────
+  describe("ML5_CACHE_PREFIX", () => {
+    it("is a non-empty string", () => {
+      expect(typeof ML5_CACHE_PREFIX).toBe("string");
+      expect(ML5_CACHE_PREFIX.length).toBeGreaterThan(0);
+    });
+
+    it("equals 'ml5-cache'", () => {
+      expect(ML5_CACHE_PREFIX).toBe("ml5-cache");
+    });
+  });
+
+  // ── FaceMesh ────────────────────────────────────────────────────────────────
+  describe("getFaceMeshUrls", () => {
+    it("returns the default (mesh) URLs when called with no options", () => {
+      const { detector, landmark } = getFaceMeshUrls();
+      expect(detector).toContain("tfhub.dev");
+      expect(detector).toContain("face_detection");
+      expect(landmark).toContain("face_mesh");
+    });
+
+    it("returns mesh URLs when refineLandmarks is false", () => {
+      const { landmark } = getFaceMeshUrls({ refineLandmarks: false });
+      expect(landmark).toContain("face_mesh");
+      expect(landmark).not.toContain("attention_mesh");
+    });
+
+    it("returns attention URLs when refineLandmarks is true", () => {
+      const { landmark } = getFaceMeshUrls({ refineLandmarks: true });
+      expect(landmark).toContain("attention_mesh");
+      expect(landmark).not.toContain("face_mesh");
+    });
+
+    it("returns the same detector URL regardless of refineLandmarks", () => {
+      const a = getFaceMeshUrls({ refineLandmarks: false });
+      const b = getFaceMeshUrls({ refineLandmarks: true });
+      expect(a.detector).toBe(b.detector);
+    });
+
+    it("returns objects with detector and landmark keys", () => {
+      const urls = getFaceMeshUrls();
+      expect(urls).toHaveProperty("detector");
+      expect(urls).toHaveProperty("landmark");
+    });
+  });
+
+  describe("getFaceMeshCacheKeys", () => {
+    it("returns keys prefixed with ML5_CACHE_PREFIX", () => {
+      const keys = getFaceMeshCacheKeys();
+      expect(keys.detector).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+      expect(keys.landmark).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+    });
+
+    it("returns the mesh landmark key when refineLandmarks is false", () => {
+      const { landmark } = getFaceMeshCacheKeys({ refineLandmarks: false });
+      expect(landmark).toContain("mesh");
+      expect(landmark).not.toContain("attention");
+    });
+
+    it("returns the attention landmark key when refineLandmarks is true", () => {
+      const { landmark } = getFaceMeshCacheKeys({ refineLandmarks: true });
+      expect(landmark).toContain("attention");
+    });
+
+    it("returns different landmark keys for the two variants", () => {
+      const mesh = getFaceMeshCacheKeys({ refineLandmarks: false });
+      const attention = getFaceMeshCacheKeys({ refineLandmarks: true });
+      expect(mesh.landmark).not.toBe(attention.landmark);
+    });
+
+    it("returns the same detector key regardless of refineLandmarks", () => {
+      const mesh = getFaceMeshCacheKeys({ refineLandmarks: false });
+      const attention = getFaceMeshCacheKeys({ refineLandmarks: true });
+      expect(mesh.detector).toBe(attention.detector);
+    });
+  });
+
+  // ── HandPose ────────────────────────────────────────────────────────────────
+  describe("getHandPoseUrls", () => {
+    it("defaults to the full model URLs", () => {
+      const { detector, landmark } = getHandPoseUrls();
+      expect(detector).toContain("full");
+      expect(landmark).toContain("full");
+    });
+
+    it("returns full URLs when modelType is 'full'", () => {
+      const { detector, landmark } = getHandPoseUrls({ modelType: "full" });
+      expect(detector).toContain("full");
+      expect(landmark).toContain("full");
+    });
+
+    it("returns lite URLs when modelType is 'lite'", () => {
+      const { detector, landmark } = getHandPoseUrls({ modelType: "lite" });
+      expect(detector).toContain("lite");
+      expect(landmark).toContain("lite");
+    });
+
+    it("returns different detector URLs for full vs lite", () => {
+      const full = getHandPoseUrls({ modelType: "full" });
+      const lite = getHandPoseUrls({ modelType: "lite" });
+      expect(full.detector).not.toBe(lite.detector);
+      expect(full.landmark).not.toBe(lite.landmark);
+    });
+
+    it("returns TFHub URLs", () => {
+      const { detector, landmark } = getHandPoseUrls();
+      expect(detector).toContain("tfhub.dev");
+      expect(landmark).toContain("tfhub.dev");
+    });
+  });
+
+  describe("getHandPoseCacheKeys", () => {
+    it("defaults to full model keys", () => {
+      const { detector, landmark } = getHandPoseCacheKeys();
+      expect(detector).toContain("full");
+      expect(landmark).toContain("full");
+    });
+
+    it("returns lite keys when modelType is 'lite'", () => {
+      const { detector, landmark } = getHandPoseCacheKeys({
+        modelType: "lite",
+      });
+      expect(detector).toContain("lite");
+      expect(landmark).toContain("lite");
+    });
+
+    it("keys are prefixed with ML5_CACHE_PREFIX", () => {
+      const keys = getHandPoseCacheKeys();
+      expect(keys.detector).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+      expect(keys.landmark).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+    });
+
+    it("full and lite keys are different", () => {
+      const full = getHandPoseCacheKeys({ modelType: "full" });
+      const lite = getHandPoseCacheKeys({ modelType: "lite" });
+      expect(full.detector).not.toBe(lite.detector);
+      expect(full.landmark).not.toBe(lite.landmark);
+    });
+  });
+
+  // ── BodyPose MoveNet ─────────────────────────────────────────────────────────
+  describe("getBodyPoseMoveNetUrl", () => {
+    it("defaults to MULTIPOSE_LIGHTNING", () => {
+      const url = getBodyPoseMoveNetUrl();
+      expect(url).toContain("multipose");
+      expect(url).toContain("lightning");
+    });
+
+    it("returns the correct URL for SINGLEPOSE_LIGHTNING", () => {
+      const url = getBodyPoseMoveNetUrl({ modelType: "SINGLEPOSE_LIGHTNING" });
+      expect(url).toContain("singlepose");
+      expect(url).toContain("lightning");
+    });
+
+    it("returns the correct URL for SINGLEPOSE_THUNDER", () => {
+      const url = getBodyPoseMoveNetUrl({ modelType: "SINGLEPOSE_THUNDER" });
+      expect(url).toContain("singlepose");
+      expect(url).toContain("thunder");
+    });
+
+    it("returns the correct URL for MULTIPOSE_LIGHTNING", () => {
+      const url = getBodyPoseMoveNetUrl({ modelType: "MULTIPOSE_LIGHTNING" });
+      expect(url).toContain("multipose");
+      expect(url).toContain("lightning");
+    });
+
+    it("returns a TFHub URL", () => {
+      const url = getBodyPoseMoveNetUrl();
+      expect(url).toContain("tfhub.dev");
+    });
+
+    it("returns different URLs for different modelTypes", () => {
+      const a = getBodyPoseMoveNetUrl({ modelType: "SINGLEPOSE_LIGHTNING" });
+      const b = getBodyPoseMoveNetUrl({ modelType: "SINGLEPOSE_THUNDER" });
+      const c = getBodyPoseMoveNetUrl({ modelType: "MULTIPOSE_LIGHTNING" });
+      expect(a).not.toBe(b);
+      expect(a).not.toBe(c);
+      expect(b).not.toBe(c);
+    });
+  });
+
+  describe("getBodyPoseMoveNetCacheKey", () => {
+    it("defaults to MULTIPOSE_LIGHTNING key", () => {
+      const key = getBodyPoseMoveNetCacheKey();
+      expect(key).toContain("multipose");
+      expect(key).toContain("lightning");
+    });
+
+    it("is prefixed with ML5_CACHE_PREFIX", () => {
+      const key = getBodyPoseMoveNetCacheKey();
+      expect(key).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+    });
+
+    it("uses hyphens, not underscores", () => {
+      const key = getBodyPoseMoveNetCacheKey({
+        modelType: "SINGLEPOSE_LIGHTNING",
+      });
+      expect(key).not.toContain("_");
+    });
+
+    it("returns different keys for different modelTypes", () => {
+      const a = getBodyPoseMoveNetCacheKey({
+        modelType: "SINGLEPOSE_LIGHTNING",
+      });
+      const b = getBodyPoseMoveNetCacheKey({ modelType: "SINGLEPOSE_THUNDER" });
+      const c = getBodyPoseMoveNetCacheKey({
+        modelType: "MULTIPOSE_LIGHTNING",
+      });
+      expect(a).not.toBe(b);
+      expect(a).not.toBe(c);
+    });
+  });
+
+  // ── BodyPose BlazePose ───────────────────────────────────────────────────────
+  describe("getBodyPoseBlazePoseUrls", () => {
+    it("defaults to the full landmark model", () => {
+      const { landmark } = getBodyPoseBlazePoseUrls();
+      expect(landmark).toContain("full");
+    });
+
+    it("returns lite landmark URL for modelType 'lite'", () => {
+      const { landmark } = getBodyPoseBlazePoseUrls({ modelType: "lite" });
+      expect(landmark).toContain("lite");
+    });
+
+    it("returns heavy landmark URL for modelType 'heavy'", () => {
+      const { landmark } = getBodyPoseBlazePoseUrls({ modelType: "heavy" });
+      expect(landmark).toContain("heavy");
+    });
+
+    it("returns the same detector URL for all modelTypes", () => {
+      const a = getBodyPoseBlazePoseUrls({ modelType: "lite" });
+      const b = getBodyPoseBlazePoseUrls({ modelType: "full" });
+      const c = getBodyPoseBlazePoseUrls({ modelType: "heavy" });
+      expect(a.detector).toBe(b.detector);
+      expect(b.detector).toBe(c.detector);
+    });
+
+    it("returns TFHub URLs", () => {
+      const { detector, landmark } = getBodyPoseBlazePoseUrls();
+      expect(detector).toContain("tfhub.dev");
+      expect(landmark).toContain("tfhub.dev");
+    });
+
+    it("returns different landmark URLs for lite/full/heavy", () => {
+      const lite = getBodyPoseBlazePoseUrls({ modelType: "lite" });
+      const full = getBodyPoseBlazePoseUrls({ modelType: "full" });
+      const heavy = getBodyPoseBlazePoseUrls({ modelType: "heavy" });
+      expect(lite.landmark).not.toBe(full.landmark);
+      expect(full.landmark).not.toBe(heavy.landmark);
+    });
+  });
+
+  describe("getBodyPoseBlazePoseCacheKeys", () => {
+    it("defaults to full landmark key", () => {
+      const { landmark } = getBodyPoseBlazePoseCacheKeys();
+      expect(landmark).toContain("full");
+    });
+
+    it("keys are prefixed with ML5_CACHE_PREFIX", () => {
+      const keys = getBodyPoseBlazePoseCacheKeys();
+      expect(keys.detector).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+      expect(keys.landmark).toMatch(new RegExp(`^${ML5_CACHE_PREFIX}`));
+    });
+
+    it("returns different landmark keys for lite/full/heavy", () => {
+      const lite = getBodyPoseBlazePoseCacheKeys({ modelType: "lite" });
+      const full = getBodyPoseBlazePoseCacheKeys({ modelType: "full" });
+      const heavy = getBodyPoseBlazePoseCacheKeys({ modelType: "heavy" });
+      expect(lite.landmark).not.toBe(full.landmark);
+      expect(full.landmark).not.toBe(heavy.landmark);
+    });
+
+    it("returns the same detector key regardless of modelType", () => {
+      const lite = getBodyPoseBlazePoseCacheKeys({ modelType: "lite" });
+      const full = getBodyPoseBlazePoseCacheKeys({ modelType: "full" });
+      const heavy = getBodyPoseBlazePoseCacheKeys({ modelType: "heavy" });
+      expect(lite.detector).toBe(full.detector);
+      expect(full.detector).toBe(heavy.detector);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,6 +1635,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mapbox/node-pre-gyp@npm:1.0.9":
+  version: 1.0.9
+  resolution: "@mapbox/node-pre-gyp@npm:1.0.9"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    https-proxy-agent: "npm:^5.0.0"
+    make-dir: "npm:^3.1.0"
+    node-fetch: "npm:^2.6.7"
+    nopt: "npm:^5.0.0"
+    npmlog: "npm:^5.0.1"
+    rimraf: "npm:^3.0.2"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.1.11"
+  bin:
+    node-pre-gyp: bin/node-pre-gyp
+  checksum: 10c0/5b32a2c3bf44e0340a29cc82cbb726bc8f49aa721388fa741afb790035975299a114b907018fc35832896cde7fa11ba2c703e2ccfd1f5a99ffe1c57814f58571
+  languageName: node
+  linkType: hard
+
 "@mediapipe/face_mesh@npm:^0.4.1633559619":
   version: 0.4.1633559619
   resolution: "@mediapipe/face_mesh@npm:0.4.1633559619"
@@ -1907,6 +1926,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tensorflow/tfjs-node@npm:^4.22.0":
+  version: 4.22.0
+  resolution: "@tensorflow/tfjs-node@npm:4.22.0"
+  dependencies:
+    "@mapbox/node-pre-gyp": "npm:1.0.9"
+    "@tensorflow/tfjs": "npm:4.22.0"
+    adm-zip: "npm:^0.5.2"
+    google-protobuf: "npm:^3.9.2"
+    https-proxy-agent: "npm:^2.2.1"
+    progress: "npm:^2.0.0"
+    rimraf: "npm:^2.6.2"
+    tar: "npm:^6.2.1"
+  checksum: 10c0/bb8cada9ca1291f71d60062c9789b3e0edd694cb430defef82cc7cae8701de5fd911f237e8b795ba7e94bafca3b184375446e0b531b2e0b4e2dc833761aa2994
+  languageName: node
+  linkType: hard
+
 "@tensorflow/tfjs-vis@npm:^1.5.1":
   version: 1.5.1
   resolution: "@tensorflow/tfjs-vis@npm:1.5.1"
@@ -1924,7 +1959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tensorflow/tfjs@npm:^4.22.0":
+"@tensorflow/tfjs@npm:4.22.0, @tensorflow/tfjs@npm:^4.22.0":
   version: 4.22.0
   resolution: "@tensorflow/tfjs@npm:4.22.0"
   dependencies:
@@ -2576,6 +2611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abbrev@npm:1":
+  version: 1.1.1
+  resolution: "abbrev@npm:1.1.1"
+  checksum: 10c0/3f762677702acb24f65e813070e306c61fafe25d4b2583f9dfc935131f774863f3addd5741572ed576bd69cabe473c5af18e1e108b829cb7b6b4747884f726e6
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -2621,12 +2663,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"adm-zip@npm:^0.5.2":
+  version: 0.5.16
+  resolution: "adm-zip@npm:0.5.16"
+  checksum: 10c0/6f10119d4570c7ba76dcf428abb8d3f69e63f92e51f700a542b43d4c0130373dd2ddfc8f85059f12d4a843703a90c3970cfd17876844b4f3f48bf042bfa6b49f
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:6":
   version: 6.0.2
   resolution: "agent-base@npm:6.0.2"
   dependencies:
     debug: "npm:4"
   checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "agent-base@npm:4.3.0"
+  dependencies:
+    es6-promisify: "npm:^5.0.0"
+  checksum: 10c0/a618d4e4ca7c0c2023b2664346570773455c501a930718764f65016a8a9eea6d2ab5ba54255589e46de529bab4026a088523dce17f94e34ba385af1f644febe1
   languageName: node
   linkType: hard
 
@@ -2793,6 +2851,23 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
+  languageName: node
+  linkType: hard
+
+"aproba@npm:^1.0.3 || ^2.0.0":
+  version: 2.1.0
+  resolution: "aproba@npm:2.1.0"
+  checksum: 10c0/ec8c1d351bac0717420c737eb062766fb63bde1552900e0f4fdad9eb064c3824fef23d1c416aa5f7a80f21ca682808e902d79b7c9ae756d342b5f1884f36932f
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "are-we-there-yet@npm:2.0.0"
+  dependencies:
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 10c0/375f753c10329153c8d66dc95e8f8b6c7cc2aa66e05cb0960bd69092b10dae22900cacc7d653ad11d26b3ecbdbfe1e8bfb6ccf0265ba8077a7d979970f16b99c
   languageName: node
   linkType: hard
 
@@ -3365,6 +3440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-support@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "color-support@npm:1.1.3"
+  bin:
+    color-support: bin.js
+  checksum: 10c0/8ffeaa270a784dc382f62d9be0a98581db43e11eee301af14734a6d089bd456478b1a8b3e7db7ca7dc5b18a75f828f775c44074020b51c05fc00e6d0992b1cc6
+  languageName: node
+  linkType: hard
+
 "colorette@npm:^2.0.10, colorette@npm:^2.0.14":
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
@@ -3444,6 +3528,13 @@ __metadata:
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
   checksum: 10c0/90fa8b16ab76e9531646cc70b010b1dbd078153730c510d3142f6cf07479ae8a812c5a3c0e40a28528dd1681a62395d0cfdef67da9e914c4772ac85d69a3ed87
+  languageName: node
+  linkType: hard
+
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "console-control-strings@npm:1.1.0"
+  checksum: 10c0/7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
   languageName: node
   linkType: hard
 
@@ -3961,6 +4052,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^3.1.0":
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
+  dependencies:
+    ms: "npm:^2.1.1"
+  checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
 "decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
@@ -4035,6 +4135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delegates@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "delegates@npm:1.0.0"
+  checksum: 10c0/ba05874b91148e1db4bf254750c042bf2215febd23a6d3cda2e64896aef79745fbd4b9996488bd3cafb39ce19dbce0fd6e3b6665275638befffe1c9b312b91b5
+  languageName: node
+  linkType: hard
+
 "depd@npm:2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
@@ -4053,6 +4160,13 @@ __metadata:
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10c0/bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
@@ -4307,6 +4421,22 @@ __metadata:
   version: 1.5.4
   resolution: "es-module-lexer@npm:1.5.4"
   checksum: 10c0/300a469488c2f22081df1e4c8398c78db92358496e639b0df7f89ac6455462aaf5d8893939087c1a1cbcbf20eed4610c70e0bcb8f3e4b0d80a5d2611c539408c
+  languageName: node
+  linkType: hard
+
+"es6-promise@npm:^4.0.3":
+  version: 4.2.8
+  resolution: "es6-promise@npm:4.2.8"
+  checksum: 10c0/2373d9c5e9a93bdd9f9ed32ff5cb6dd3dd785368d1c21e9bbbfd07d16345b3774ae260f2bd24c8f836a6903f432b4151e7816a7fa8891ccb4e1a55a028ec42c3
+  languageName: node
+  linkType: hard
+
+"es6-promisify@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "es6-promisify@npm:5.0.0"
+  dependencies:
+    es6-promise: "npm:^4.0.3"
+  checksum: 10c0/23284c6a733cbf7842ec98f41eac742c9f288a78753c4fe46652bae826446ced7615b9e8a5c5f121a08812b1cd478ea58630f3e1c3d70835bd5dcd69c7cd75c9
   languageName: node
   linkType: hard
 
@@ -4765,6 +4895,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gauge@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "gauge@npm:3.0.2"
+  dependencies:
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.2"
+    console-control-strings: "npm:^1.0.0"
+    has-unicode: "npm:^2.0.1"
+    object-assign: "npm:^4.1.1"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.2"
+  checksum: 10c0/75230ccaf216471e31025c7d5fcea1629596ca20792de50c596eb18ffb14d8404f927cd55535aab2eeecd18d1e11bd6f23ec3c2e9878d2dda1dc74bccc34b913
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -4872,6 +5019,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-protobuf@npm:^3.9.2":
+  version: 3.21.4
+  resolution: "google-protobuf@npm:3.21.4"
+  checksum: 10c0/28f2800f7fe1a8fc55eb58ba76e158268407bfb3b90646eaf8a177dd92a2e522459b773f8132ae546e60ac3b6f5947557a1cf3d963a05bb594f43bcde640f54f
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1":
   version: 1.0.1
   resolution: "gopd@npm:1.0.1"
@@ -4922,6 +5076,13 @@ __metadata:
   version: 1.0.3
   resolution: "has-symbols@npm:1.0.3"
   checksum: 10c0/e6922b4345a3f37069cdfe8600febbca791c94988c01af3394d86ca3360b4b93928bbf395859158f88099cb10b19d98e3bbab7c9ff2c1bd09cf665ee90afa2c3
+  languageName: node
+  linkType: hard
+
+"has-unicode@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "has-unicode@npm:2.0.1"
+  checksum: 10c0/ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
   languageName: node
   linkType: hard
 
@@ -5124,7 +5285,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.1":
+"https-proxy-agent@npm:^2.2.1":
+  version: 2.2.4
+  resolution: "https-proxy-agent@npm:2.2.4"
+  dependencies:
+    agent-base: "npm:^4.3.0"
+    debug: "npm:^3.1.0"
+  checksum: 10c0/4bdde8fcd9ea0adc4a77282de2b4f9e27955e0441425af0f27f0fe01006946b80eaee6749e08e838d350c06ed2ebd5d11347d3beb88c45eacb0667e27276cdad
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -6301,6 +6472,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-dir@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "make-dir@npm:3.1.0"
+  dependencies:
+    semver: "npm:^6.0.0"
+  checksum: 10c0/56aaafefc49c2dfef02c5c95f9b196c4eb6988040cf2c712185c7fe5c99b4091591a7fc4d4eafaaefa70ff763a26f6ab8c3ff60b9e75ea19876f49b18667ecaa
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^4.0.0":
   version: 4.0.0
   resolution: "make-dir@npm:4.0.0"
@@ -6570,6 +6750,7 @@ __metadata:
     "@tensorflow-models/speech-commands": "npm:^0.5.4"
     "@tensorflow/tfjs": "npm:^4.22.0"
     "@tensorflow/tfjs-backend-webgpu": "npm:^4.22.0"
+    "@tensorflow/tfjs-node": "npm:^4.22.0"
     "@tensorflow/tfjs-vis": "npm:^1.5.1"
     all-contributors-cli: "npm:^6.26.1"
     axios: "npm:^1.3.4"
@@ -6599,7 +6780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.1.3":
+"ms@npm:2.1.3, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -6742,6 +6923,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nopt@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "nopt@npm:5.0.0"
+  dependencies:
+    abbrev: "npm:1"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10c0/fc5c4f07155cb455bf5fc3dd149fac421c1a40fd83c6bfe83aa82b52f02c17c5e88301321318adaa27611c8a6811423d51d29deaceab5fa158b585a61a551061
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^7.0.0":
   version: 7.2.1
   resolution: "nopt@npm:7.2.1"
@@ -6766,6 +6958,18 @@ __metadata:
   dependencies:
     path-key: "npm:^3.0.0"
   checksum: 10c0/6f9353a95288f8455cf64cbeb707b28826a7f29690244c1e4bb61ec573256e021b6ad6651b394eb1ccfd00d6ec50147253aba2c5fe58a57ceb111fad62c519ac
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "npmlog@npm:5.0.1"
+  dependencies:
+    are-we-there-yet: "npm:^2.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^3.0.0"
+    set-blocking: "npm:^2.0.0"
+  checksum: 10c0/489ba519031013001135c463406f55491a17fc7da295c18a04937fe3a4d523fd65e88dd418a28b967ab743d913fdeba1e29838ce0ad8c75557057c481f7d49fa
   languageName: node
   linkType: hard
 
@@ -7157,6 +7361,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"progress@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "progress@npm:2.0.3"
+  checksum: 10c0/1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -7310,7 +7521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.6":
+"readable-stream@npm:^3.0.6, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -7531,7 +7742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.3":
+"rimraf@npm:^2.6.2, rimraf@npm:^2.6.3":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:
@@ -7664,7 +7875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:^6.0.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -7825,7 +8036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -8009,7 +8220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -9375,6 +9586,15 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/449fa5c44ed120ccecfe18c433296a4978a7583bf2391c50abce13f76878d2476defde04d0f79db8165bdf432853c1f8389d0485ca6e8ebce3bbcded513d5e6a
+  languageName: node
+  linkType: hard
+
+"wide-align@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "wide-align@npm:1.1.5"
+  dependencies:
+    string-width: "npm:^1.0.2 || 2 || 3 || 4"
+  checksum: 10c0/1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This pull request adds support for offline model caching using the browser's IndexedDB. By passing `{ cache: true }` when initializing models like `handPose`, `bodyPose`, and `faceMesh`, the models are transparently downloaded and stored locally. On subsequent page loads, the models are served directly from the IndexedDB cache, making the library fully functional without an internet connection (ideal for installations and exhibitions).

## Changes
*   **Model Caching:** Added `CachingIOHandler` in `src/utils/modelCache.js` to intercept TensorFlow.js model requests and store them in IndexedDB.
*   **Model Registry:** Added `src/utils/modelRegistry.js` to resolve dynamic model URLs for caching.
*   **Global Utilities:** Introduced `ml5.isCached()`, `ml5.cacheModel()`, and `ml5.clearCache()` to manually manage the IndexedDB state.
*   **Robust Initialization:** Added `await this.ready;` across `detect()` and `detectLoop()` methods in all major models to prevent synchronous crashes when `this.model` is `null` during background initialization.
*   **Examples:** Added one example of handpose offline available at `examples/handPose-keypoints-offline` to showcase how to preload and use models in an offline environment, keeping the UI minimal and consistent with other examples.