### PR TITLE
Add ml5 cache CLI and modelPath option for offline model loading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Welcome to the ml5.js project! Developing ml5.js is not just about developing ma
     - [General Guidelines](#general-guidelines)
     - [Image/Video-Based Detection Models](#imagevideo-based-detection-models)
   - [Utils](#utils)
+    - [Updating offline model files](#updating-offline-model-files)
     - [handleOptions](#handleoptions)
       - [`userObject`](#userobject)
       - [`moldObject`](#moldobject)
@@ -321,6 +322,15 @@ This guideline provides a high-level concept of what the ml5.js library's API sh
 ## Utils
 
 This section documents the utility functions found in the `src/utils` folder.
+
+### Updating offline model files
+
+Offline model support uses `src/utils/modelRegistry.js` as the source of truth for TFJS model URLs and MediaPipe file lists. When bumping model packages or changing upstream URLs:
+
+1. Update `src/utils/modelRegistry.js`.
+2. Run `ml5 cache prefetch <model> --force` for each affected model.
+3. Run `ml5 cache verify <model>` to confirm the generated `manifest.json` checksums.
+4. Test the corresponding example with DevTools Network open and confirm model files are loaded from `localhost`.
 
 ### [handleOptions](src\utils\handleOptions.js)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Before getting started with ml5.js, review our [Code of Conduct](https://github.
 
   **Note:** To access the source code of version `0.12.2` or earlier, please visit the [archived repository](https://github.com/ml5js/ml5-library).
 
+## Offline mode
+
+For local installations, exhibitions, and classrooms without reliable internet, ml5 can load model files from a normal folder served by your local web server:
+
+```bash
+npx ml5 cache prefetch handpose
+```
+
+```js
+let handPose = ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+See [docs/offline-mode.md](docs/offline-mode.md) for the full guide.
+
 
 ## Resources
 

--- a/bin/ml5.js
+++ b/bin/ml5.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require("../cli")(process.argv.slice(2)).catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,6 +44,33 @@ non-cache CLI commands without changing the subcommand modules.
 - TFJS shard filenames are not hardcoded. They are discovered from each
   downloaded `model.json` file's `weightsManifest`.
 
+## Registry duplication
+
+`cli/registry.js` is a CommonJS mirror of `src/utils/modelRegistry.js` (ESM).
+They must be kept in sync by hand for v1.
+
+**Why duplicated:** the CLI is invoked via `bin/ml5.js` as plain Node CommonJS
+with no build step. Importing the ESM runtime registry directly would require
+either an ESM CLI entry point, which raises the floor for contributors, or a
+build step that runs before `bin/ml5.js` is usable from a checkout, which breaks
+`node bin/ml5.js` ergonomics.
+
+**How to keep them in sync:**
+
+1. When you add or change a model URL or file list in
+   `src/utils/modelRegistry.js`, mirror the change in `cli/registry.js` in the
+   same commit.
+2. Run `node bin/ml5.js cache prefetch <model>` followed by
+   `node bin/ml5.js cache verify <model>` to confirm the CLI side resolves
+   correctly.
+
+**Planned follow-up (not in this PR):**
+
+- Add a registry-drift unit test that diffs the two registries and fails CI on
+  mismatch.
+- Either generate `cli/registry.js` at build time from the runtime registry, or
+  extract the shared data into a plain `.json` file consumed by both.
+
 ## Known follow-ups
 
 - `clear.js` and `verify.js` use lightweight positional parsing. Replace them

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,64 @@
+# ml5 cache CLI internals
+
+This directory contains the Node source for the `ml5 cache ...` command group.
+For user-facing instructions, start with [`../docs/offline-mode.md`](../docs/offline-mode.md).
+
+## Entry flow
+
+```text
+bin/ml5.js   shebang executable; forwards process.argv to ../cli/index.js
+cli/index.js top-level dispatcher for cache prefetch | list | clear | verify | models
+```
+
+`bin/ml5.js` is the published executable declared in `package.json#bin`. The
+dispatcher currently accepts only the `cache` group, leaving room for future
+non-cache CLI commands without changing the subcommand modules.
+
+## Subcommand modules
+
+- `prefetch.js` downloads/copies model assets and writes `manifest.json`.
+- `list.js` enumerates cached model folders from `<out>`.
+- `clear.js` removes one model cache folder, or the entire cache folder.
+- `verify.js` re-hashes cached files and reports manifest mismatches.
+- `models.js` prints the registered models and MediaPipe variants.
+
+## Shared modules
+
+- `registry.js` mirrors the runtime registry for Node/CommonJS use.
+- `utils/paths.js` resolves `--out` and builds model/runtime subdirectories.
+- `utils/manifest.js` reads, writes, and verifies cache manifests.
+- `utils/sha.js` streams files through SHA-256 hashing.
+- `utils/copy-mediapipe.js` copies MediaPipe assets from `node_modules`.
+- `utils/download-tfjs.js` downloads TFJS `model.json` files and shards.
+- `utils/progress.js` centralizes quiet-aware progress logging.
+- `utils/size.js` formats byte counts for human-readable output.
+
+## Key design decisions
+
+- The default `prefetch` runtime is `both`, so the command prompts before
+  staging large downloads and requires `--yes` in non-interactive shells.
+- The SHA-256 manifest is the on-disk contract that
+  `src/utils/modelResolver.js` probes when a sketch uses `modelPath`.
+- MediaPipe filenames are hardcoded because package layouts are stable; package
+  versions are read at runtime from each installed `@mediapipe/*` package.
+- TFJS shard filenames are not hardcoded. They are discovered from each
+  downloaded `model.json` file's `weightsManifest`.
+
+## Known follow-ups
+
+- `clear.js` and `verify.js` use lightweight positional parsing. Replace them
+  with a shared parser before adding more flags.
+- `copy-mediapipe.js` re-hashes every copied/reused file on each run. Cache hash
+  results if that becomes slow for larger model sets.
+- `registry.js` intentionally mirrors `src/utils/modelRegistry.js` until the
+  project has a shared source format or generator that works in Node and the
+  browser bundle.
+
+## See also
+
+- [`../src/utils/modelResolver.js`](../src/utils/modelResolver.js) — runtime
+  consumer of `<out>/<model>/manifest.json`.
+- [`../src/utils/modelRegistry.js`](../src/utils/modelRegistry.js) — canonical
+  runtime URL/file-list source.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — see "Updating offline model
+  files" for the contributor checklist.

--- a/cli/clear.js
+++ b/cli/clear.js
@@ -1,3 +1,10 @@
+/**
+ * cli/clear.js
+ *
+ * Implements `ml5 cache clear [model] [--out <dir>]` by removing either one
+ * cached model directory or the entire cache output directory.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { resolveOutDir } = require("./utils/paths");
@@ -5,6 +12,9 @@ const { resolveOutDir } = require("./utils/paths");
 async function clear(args) {
   const outIndex = args.indexOf("--out");
   const out = resolveOutDir(outIndex >= 0 ? args[outIndex + 1] : "ml5-models");
+  // TODO: Replace this lightweight positional parsing with a shared parser.
+  // Today `--out foo handpose` works, but unusual flag ordering can be
+  // surprising because we only skip the value immediately following --out.
   const model = args.find((arg) => !arg.startsWith("--") && arg !== (outIndex >= 0 ? args[outIndex + 1] : undefined));
   const target = model ? path.join(out, model.toLowerCase()) : out;
   await fs.rm(target, { recursive: true, force: true });

--- a/cli/clear.js
+++ b/cli/clear.js
@@ -1,0 +1,14 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { resolveOutDir } = require("./utils/paths");
+
+async function clear(args) {
+  const outIndex = args.indexOf("--out");
+  const out = resolveOutDir(outIndex >= 0 ? args[outIndex + 1] : "ml5-models");
+  const model = args.find((arg) => !arg.startsWith("--") && arg !== (outIndex >= 0 ? args[outIndex + 1] : undefined));
+  const target = model ? path.join(out, model.toLowerCase()) : out;
+  await fs.rm(target, { recursive: true, force: true });
+  console.log(`Cleared ${target}`);
+}
+
+module.exports = { clear };

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,3 +1,11 @@
+/**
+ * cli/index.js
+ *
+ * Top-level dispatcher for the `ml5` executable. Today the CLI exposes the
+ * `cache` command group only, but this file keeps the group check explicit so
+ * future non-cache commands can be added without rewriting each subcommand.
+ */
+
 const { prefetch } = require("./prefetch");
 const { list } = require("./list");
 const { clear } = require("./clear");
@@ -17,6 +25,7 @@ Commands:
 }
 
 module.exports = async function cli(args) {
+  // Global help/version flags short-circuit before subcommand routing.
   if (args.length === 0 || args.includes("--help") || args.includes("-h")) return help();
   if (args.includes("--version")) return console.log(require("../package.json").version);
   const [group, command, ...rest] = args;

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,30 @@
+const { prefetch } = require("./prefetch");
+const { list } = require("./list");
+const { clear } = require("./clear");
+const { verify } = require("./verify");
+const { models } = require("./models");
+
+function help() {
+  console.log(`ml5 cache
+
+Commands:
+  ml5 cache prefetch <model>... [--runtime tfjs|mediapipe|both] [--variant <name>] [--out <dir>]
+  ml5 cache list [--out <dir>]
+  ml5 cache clear [model] [--out <dir>]
+  ml5 cache verify <model> [--out <dir>]
+  ml5 cache models
+`);
+}
+
+module.exports = async function cli(args) {
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) return help();
+  if (args.includes("--version")) return console.log(require("../package.json").version);
+  const [group, command, ...rest] = args;
+  if (group !== "cache") return help();
+  if (command === "prefetch") return prefetch(rest);
+  if (command === "list") return list(rest);
+  if (command === "clear") return clear(rest);
+  if (command === "verify") return verify(rest);
+  if (command === "models") return models(rest);
+  return help();
+};

--- a/cli/list.js
+++ b/cli/list.js
@@ -1,3 +1,10 @@
+/**
+ * cli/list.js
+ *
+ * Implements `ml5 cache list [--out <dir>]` by scanning the cache output
+ * directory for model folders that contain a manifest.json.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { resolveOutDir } = require("./utils/paths");
@@ -10,6 +17,7 @@ async function list(args) {
   try {
     entries = await fs.readdir(out, { withFileTypes: true });
   } catch (error) {
+    // Missing output directories are expected before the first prefetch.
     console.log("No local ml5 model files found.");
     return;
   }

--- a/cli/list.js
+++ b/cli/list.js
@@ -1,0 +1,22 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { resolveOutDir } = require("./utils/paths");
+const { readManifest } = require("./utils/manifest");
+
+async function list(args) {
+  const outIndex = args.indexOf("--out");
+  const out = resolveOutDir(outIndex >= 0 ? args[outIndex + 1] : "ml5-models");
+  let entries = [];
+  try {
+    entries = await fs.readdir(out, { withFileTypes: true });
+  } catch (error) {
+    console.log("No local ml5 model files found.");
+    return;
+  }
+  for (const entry of entries.filter((item) => item.isDirectory())) {
+    const manifest = await readManifest(path.join(out, entry.name));
+    if (manifest) console.log(`${entry.name}: ${Object.keys(manifest.runtimes || {}).join(", ")}`);
+  }
+}
+
+module.exports = { list };

--- a/cli/models.js
+++ b/cli/models.js
@@ -1,0 +1,10 @@
+const { mediapipePackages, tfjsModels } = require("./registry");
+
+async function models() {
+  Object.keys(tfjsModels).forEach((model) => {
+    const variants = Object.keys(mediapipePackages[model]?.variants || {}).join(", ");
+    console.log(`${model}  runtimes: tfjs, mediapipe  mediapipe variants: ${variants}`);
+  });
+}
+
+module.exports = { models };

--- a/cli/models.js
+++ b/cli/models.js
@@ -1,3 +1,10 @@
+/**
+ * cli/models.js
+ *
+ * Implements `ml5 cache models`, a small discovery command that prints every
+ * cacheable model plus the MediaPipe variants known to the CLI registry.
+ */
+
 const { mediapipePackages, tfjsModels } = require("./registry");
 
 async function models() {

--- a/cli/prefetch.js
+++ b/cli/prefetch.js
@@ -1,3 +1,18 @@
+/**
+ * cli/prefetch.js
+ *
+ * Implements `ml5 cache prefetch <model>...`.
+ *
+ * Per model, this:
+ *   1. Optionally prompts before staging large downloads.
+ *   2. Copies MediaPipe assets from node_modules into <out>/<model>/mediapipe/.
+ *   3. Downloads TFJS model.json + weight shards into <out>/<model>/tfjs/<sub>/.
+ *   4. Writes <out>/<model>/manifest.json with SHA-256 + size for every file.
+ *
+ * The manifest is the contract that resolveModelUrls() probes when a sketch
+ * sets `modelPath: "auto"` or points `modelPath` at a local model root.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const pkg = require("../package.json");
@@ -10,6 +25,8 @@ const { log } = require("./utils/progress");
 const { getModelDirName, tfjsModels } = require("./registry");
 
 async function confirmLargeDownload(options) {
+  // The default `both` runtime can stage >30 MB. In CI/non-TTY contexts, fail
+  // fast unless the caller explicitly opts in with --yes.
   if (options.yes || options.quiet || options.runtime !== "both") return;
   if (!process.stdin.isTTY) {
     throw new Error("This prefetch may download/copy more than 30 MB. Re-run with --yes to continue in a non-interactive shell.");
@@ -30,6 +47,7 @@ function parseOptions(args) {
     else if (arg === "--force") options.force = true;
     else if (arg === "--yes") options.yes = true;
     else if (arg === "--quiet") options.quiet = true;
+    // Positional arguments are model names; normalize to registry keys.
     else options.models.push(arg.toLowerCase());
   }
   return options;
@@ -64,6 +82,8 @@ async function prefetch(args) {
       log(`  → downloading TFJS assets`, options.quiet);
       manifest.runtimes.tfjs = { files: [], sources: {} };
       for (const key of Object.keys(models)) {
+        // The generic `model` key is still staged in a `model/` subfolder so
+        // every TFJS entry has a stable runtime-local path.
         const subdir = key === "model" ? "model" : key;
         const result = await downloadTfjsModel({
           name: key,
@@ -77,6 +97,8 @@ async function prefetch(args) {
       }
     }
 
+    // writeManifest() also creates the root; this mkdir keeps the intent local
+    // to prefetch and makes the final manifest write obviously safe.
     await fs.mkdir(root, { recursive: true });
     await writeManifest(root, manifest);
     log(`✓ ${model} ready at ${root}`, options.quiet);

--- a/cli/prefetch.js
+++ b/cli/prefetch.js
@@ -1,0 +1,86 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const pkg = require("../package.json");
+const readline = require("node:readline/promises");
+const { copyMediaPipe } = require("./utils/copy-mediapipe");
+const { downloadTfjsModel } = require("./utils/download-tfjs");
+const { writeManifest } = require("./utils/manifest");
+const { modelRoot, runtimeDir } = require("./utils/paths");
+const { log } = require("./utils/progress");
+const { getModelDirName, tfjsModels } = require("./registry");
+
+async function confirmLargeDownload(options) {
+  if (options.yes || options.quiet || options.runtime !== "both") return;
+  if (!process.stdin.isTTY) {
+    throw new Error("This prefetch may download/copy more than 30 MB. Re-run with --yes to continue in a non-interactive shell.");
+  }
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question("This may stage more than 30 MB of model files. Continue? [y/N] ");
+  rl.close();
+  if (!/^y(es)?$/i.test(answer.trim())) throw new Error("Prefetch cancelled.");
+}
+
+function parseOptions(args) {
+  const options = { models: [], out: "ml5-models", runtime: "both", variant: undefined, force: false, yes: false, quiet: false };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--out") options.out = args[++i];
+    else if (arg === "--runtime") options.runtime = args[++i];
+    else if (arg === "--variant") options.variant = args[++i];
+    else if (arg === "--force") options.force = true;
+    else if (arg === "--yes") options.yes = true;
+    else if (arg === "--quiet") options.quiet = true;
+    else options.models.push(arg.toLowerCase());
+  }
+  return options;
+}
+
+async function prefetch(args) {
+  const options = parseOptions(args);
+  if (options.models.length === 0) throw new Error("Usage: ml5 cache prefetch <model>... [--runtime tfjs|mediapipe|both]");
+  if (!["tfjs", "mediapipe", "both"].includes(options.runtime)) throw new Error("--runtime must be tfjs, mediapipe, or both");
+
+  await confirmLargeDownload(options);
+
+  for (const model of options.models) {
+    const modelDirName = getModelDirName(model);
+    const root = modelRoot(options.out, modelDirName);
+    const manifest = { $schema: "ml5-models-manifest-v1", model, createdAt: new Date().toISOString(), ml5Version: pkg.version, runtimes: {} };
+
+    log(`Resolving ${model}…`, options.quiet);
+    if (options.runtime === "mediapipe" || options.runtime === "both") {
+      log(`  → staging MediaPipe assets`, options.quiet);
+      manifest.runtimes.mediapipe = await copyMediaPipe({
+        model,
+        variant: options.variant,
+        destination: runtimeDir(options.out, modelDirName, "mediapipe"),
+        force: options.force,
+      });
+    }
+
+    if (options.runtime === "tfjs" || options.runtime === "both") {
+      const models = tfjsModels[model];
+      if (!models) throw new Error(`Unknown model '${model}'`);
+      log(`  → downloading TFJS assets`, options.quiet);
+      manifest.runtimes.tfjs = { files: [], sources: {} };
+      for (const key of Object.keys(models)) {
+        const subdir = key === "model" ? "model" : key;
+        const result = await downloadTfjsModel({
+          name: key,
+          url: models[key],
+          destination: path.join(runtimeDir(options.out, modelDirName, "tfjs"), subdir),
+          manifestPrefix: path.posix.join("tfjs", subdir),
+          force: options.force,
+        });
+        manifest.runtimes.tfjs.sources[key] = result.source;
+        manifest.runtimes.tfjs.files.push(...result.files);
+      }
+    }
+
+    await fs.mkdir(root, { recursive: true });
+    await writeManifest(root, manifest);
+    log(`✓ ${model} ready at ${root}`, options.quiet);
+  }
+}
+
+module.exports = { prefetch };

--- a/cli/registry.js
+++ b/cli/registry.js
@@ -1,3 +1,21 @@
+/**
+ * cli/registry.js
+ *
+ * CLI-side registry for the cache commands: model directory names, MediaPipe
+ * package/file lists, and TFJS source URLs.
+ *
+ * IMPORTANT: `src/utils/modelRegistry.js` is the browser/runtime canonical
+ * source. This CommonJS file mirrors the same information because the CLI runs
+ * directly in Node without a build step. Keep changes in sync with the runtime
+ * registry until a generator/shared format replaces this mirror.
+ *
+ * Note the key names intentionally differ from the browser registry:
+ *   - CLI:     model | detector | landmark
+ *   - Runtime: modelUrl | detectorModelUrl | landmarkModelUrl
+ * The CLI names describe local cache subdirectories; the runtime names match
+ * TensorFlow.js model config fields.
+ */
+
 const path = require("node:path");
 
 const modelDirs = {
@@ -7,6 +25,8 @@ const modelDirs = {
 };
 
 const mediapipePackages = {
+  // MediaPipe solution filenames are hardcoded because package layouts are
+  // stable within these packages; actual versions are read dynamically below.
   handpose: {
     pkg: "@mediapipe/hands",
     defaultVariant: "full",
@@ -37,6 +57,8 @@ const tfjsModels = {
     landmark: "https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1",
   },
   bodypose: {
+    // BodyPose stages both MoveNet (`model`) and BlazePose (`detector` +
+    // `landmark`) so users can choose either model from one cached folder.
     model: "https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1",
     detector: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1",
     landmark: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2",

--- a/cli/registry.js
+++ b/cli/registry.js
@@ -1,0 +1,68 @@
+const path = require("node:path");
+
+const modelDirs = {
+  handpose: "handpose",
+  facemesh: "facemesh",
+  bodypose: "bodypose",
+};
+
+const mediapipePackages = {
+  handpose: {
+    pkg: "@mediapipe/hands",
+    defaultVariant: "full",
+    shared: ["hands.binarypb", "hands.js", "hands_solution_packed_assets.data", "hands_solution_packed_assets_loader.js", "hands_solution_simd_wasm_bin.js", "hands_solution_simd_wasm_bin.wasm", "hands_solution_simd_wasm_bin.data", "hands_solution_wasm_bin.js", "hands_solution_wasm_bin.wasm"],
+    variants: { lite: ["hand_landmark_lite.tflite"], full: ["hand_landmark_full.tflite"] },
+  },
+  facemesh: {
+    pkg: "@mediapipe/face_mesh",
+    defaultVariant: "default",
+    shared: ["face_mesh.binarypb", "face_mesh.js", "face_mesh_solution_packed_assets.data", "face_mesh_solution_packed_assets_loader.js", "face_mesh_solution_simd_wasm_bin.js", "face_mesh_solution_simd_wasm_bin.wasm", "face_mesh_solution_simd_wasm_bin.data", "face_mesh_solution_wasm_bin.js", "face_mesh_solution_wasm_bin.wasm"],
+    variants: { default: [] },
+  },
+  bodypose: {
+    pkg: "@mediapipe/pose",
+    defaultVariant: "full",
+    shared: ["pose_web.binarypb", "pose.js", "pose_solution_packed_assets.data", "pose_solution_packed_assets_loader.js", "pose_solution_simd_wasm_bin.js", "pose_solution_simd_wasm_bin.wasm", "pose_solution_simd_wasm_bin.data", "pose_solution_wasm_bin.js", "pose_solution_wasm_bin.wasm"],
+    variants: { lite: ["pose_landmark_lite.tflite"], full: ["pose_landmark_full.tflite"], heavy: ["pose_landmark_heavy.tflite"] },
+  },
+};
+
+const tfjsModels = {
+  handpose: {
+    detector: "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1",
+    landmark: "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1",
+  },
+  facemesh: {
+    detector: "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+    landmark: "https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1",
+  },
+  bodypose: {
+    model: "https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1",
+    detector: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1",
+    landmark: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2",
+  },
+};
+
+function getModelDirName(model) {
+  return modelDirs[model] || model;
+}
+
+function getMediaPipeFiles(model, variant) {
+  const info = mediapipePackages[model];
+  const selected = variant || info.defaultVariant;
+  const variantFiles = selected === "all" ? Object.values(info.variants).flat() : info.variants[selected] || info.variants[info.defaultVariant] || [];
+  return [...info.shared, ...variantFiles];
+}
+
+function getMediaPipePackageDir(model) {
+  const info = mediapipePackages[model];
+  const pkgJson = require.resolve(path.join(info.pkg, "package.json"));
+  return path.dirname(pkgJson);
+}
+
+function getMediaPipeVersion(model) {
+  const info = mediapipePackages[model];
+  return require(path.join(info.pkg, "package.json")).version;
+}
+
+module.exports = { modelDirs, mediapipePackages, tfjsModels, getModelDirName, getMediaPipeFiles, getMediaPipePackageDir, getMediaPipeVersion };

--- a/cli/utils/copy-mediapipe.js
+++ b/cli/utils/copy-mediapipe.js
@@ -1,0 +1,28 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { getMediaPipeFiles, getMediaPipePackageDir, getMediaPipeVersion, mediapipePackages } = require("../registry");
+const { sha256File } = require("./sha");
+
+async function copyMediaPipe({ model, variant, destination, force = false }) {
+  const files = getMediaPipeFiles(model, variant);
+  const packageDir = getMediaPipePackageDir(model);
+  await fs.mkdir(destination, { recursive: true });
+  const manifestFiles = [];
+  for (const file of files) {
+    const from = path.join(packageDir, file);
+    const to = path.join(destination, file);
+    let copied = true;
+    if (!force) {
+      try {
+        await fs.access(to);
+        copied = false;
+      } catch (error) {}
+    }
+    if (copied) await fs.copyFile(from, to);
+    const stat = await fs.stat(to);
+    manifestFiles.push({ path: path.posix.join("mediapipe", file), size: stat.size, sha256: await sha256File(to) });
+  }
+  return { package: mediapipePackages[model].pkg, version: getMediaPipeVersion(model), variant: variant || mediapipePackages[model].defaultVariant, files: manifestFiles };
+}
+
+module.exports = { copyMediaPipe };

--- a/cli/utils/copy-mediapipe.js
+++ b/cli/utils/copy-mediapipe.js
@@ -1,3 +1,10 @@
+/**
+ * cli/utils/copy-mediapipe.js
+ *
+ * Copies MediaPipe solution assets from installed node_modules packages into
+ * the local cache layout and records size + SHA-256 for the manifest.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { getMediaPipeFiles, getMediaPipePackageDir, getMediaPipeVersion, mediapipePackages } = require("../registry");
@@ -14,11 +21,15 @@ async function copyMediaPipe({ model, variant, destination, force = false }) {
     let copied = true;
     if (!force) {
       try {
+        // Existing files are reused unless --force is set; we still hash below
+        // so the manifest reflects the file that will actually be served.
         await fs.access(to);
         copied = false;
       } catch (error) {}
     }
     if (copied) await fs.copyFile(from, to);
+    // TODO: This intentionally verifies every copied/reused file today. If it
+    // becomes slow, cache hash results and invalidate by size + mtime.
     const stat = await fs.stat(to);
     manifestFiles.push({ path: path.posix.join("mediapipe", file), size: stat.size, sha256: await sha256File(to) });
   }

--- a/cli/utils/download-tfjs.js
+++ b/cli/utils/download-tfjs.js
@@ -1,3 +1,10 @@
+/**
+ * cli/utils/download-tfjs.js
+ *
+ * Downloads a TFJS model.json file and every weight shard listed in its
+ * weightsManifest. This lets the CLI avoid hardcoding shard filenames.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { pipeline } = require("node:stream/promises");
@@ -10,18 +17,24 @@ function toModelJsonUrl(url) {
 }
 
 function dirnameUrl(url) {
+  // Strip `/model.json` and any query string so shard paths resolve beside the
+  // fetched model file.
   return url.replace(/\/model\.json(?:\?.*)?$/, "").replace(/\/+$/, "");
 }
 
 function toShardUrl(base, shard) {
   if (/^https?:\/\//i.test(shard)) return shard;
   const url = `${base}/${shard}`;
+  // tfhub.dev requires the same file-format query for shards as model.json;
+  // omitting it can return an HTML redirect/403 instead of binary weights.
   return base.includes("tfhub.dev") ? `${url}?tfjs-format=file` : url;
 }
 
 async function download(url, filePath, force) {
   if (!force) {
     try {
+      // Reuse existing shards unless --force is set; manifest hashing later
+      // verifies the local file rather than trusting this shortcut blindly.
       await fs.access(filePath);
       return;
     } catch (error) {}

--- a/cli/utils/download-tfjs.js
+++ b/cli/utils/download-tfjs.js
@@ -1,0 +1,60 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { pipeline } = require("node:stream/promises");
+const { Readable } = require("node:stream");
+const { sha256File } = require("./sha");
+
+function toModelJsonUrl(url) {
+  if (url.includes("tfhub.dev")) return `${url.replace(/\/+$/, "")}/model.json?tfjs-format=file`;
+  return url.endsWith("model.json") ? url : `${url.replace(/\/+$/, "")}/model.json`;
+}
+
+function dirnameUrl(url) {
+  return url.replace(/\/model\.json(?:\?.*)?$/, "").replace(/\/+$/, "");
+}
+
+function toShardUrl(base, shard) {
+  if (/^https?:\/\//i.test(shard)) return shard;
+  const url = `${base}/${shard}`;
+  return base.includes("tfhub.dev") ? `${url}?tfjs-format=file` : url;
+}
+
+async function download(url, filePath, force) {
+  if (!force) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch (error) {}
+  }
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await pipeline(Readable.fromWeb(response.body), await fs.open(filePath, "w").then((fh) => fh.createWriteStream()));
+}
+
+async function downloadTfjsModel({ name, url, destination, manifestPrefix, force = false }) {
+  const modelJsonUrl = toModelJsonUrl(url);
+  const response = await fetch(modelJsonUrl);
+  if (!response.ok) throw new Error(`Failed to download ${modelJsonUrl}: HTTP ${response.status}`);
+  const modelJson = await response.text();
+  await fs.mkdir(destination, { recursive: true });
+  const modelJsonPath = path.join(destination, "model.json");
+  await fs.writeFile(modelJsonPath, modelJson);
+  const model = JSON.parse(modelJson);
+  const base = dirnameUrl(modelJsonUrl);
+  for (const group of model.weightsManifest || []) {
+    for (const shard of group.paths || []) {
+      await download(toShardUrl(base, shard), path.join(destination, shard), force);
+    }
+  }
+  const localFiles = ["model.json", ...new Set((model.weightsManifest || []).flatMap((group) => group.paths || []))];
+  const files = [];
+  for (const file of localFiles) {
+    const fullPath = path.join(destination, file);
+    const stat = await fs.stat(fullPath);
+    files.push({ path: path.posix.join(manifestPrefix, file), size: stat.size, sha256: await sha256File(fullPath) });
+  }
+  return { name, source: url, files };
+}
+
+module.exports = { downloadTfjsModel };

--- a/cli/utils/manifest.js
+++ b/cli/utils/manifest.js
@@ -1,0 +1,36 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const { sha256File } = require("./sha");
+
+async function readManifest(root) {
+  try {
+    const content = await fs.readFile(path.join(root, "manifest.json"), "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    return null;
+  }
+}
+
+async function writeManifest(root, manifest) {
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(root, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+async function verifyManifest(root, manifest) {
+  const results = [];
+  for (const runtime of Object.keys(manifest.runtimes || {})) {
+    for (const file of manifest.runtimes[runtime].files || []) {
+      const fullPath = path.join(root, file.path);
+      try {
+        const stat = await fs.stat(fullPath);
+        const sha256 = await sha256File(fullPath);
+        results.push({ ...file, runtime, ok: stat.size === file.size && sha256 === file.sha256 });
+      } catch (error) {
+        results.push({ ...file, runtime, ok: false });
+      }
+    }
+  }
+  return results;
+}
+
+module.exports = { readManifest, writeManifest, verifyManifest };

--- a/cli/utils/manifest.js
+++ b/cli/utils/manifest.js
@@ -1,3 +1,11 @@
+/**
+ * cli/utils/manifest.js
+ *
+ * Read, write, and verify <out>/<model>/manifest.json files. The manifest
+ * schema string is currently `ml5-models-manifest-v1`; bump that value in
+ * prefetch.js if the on-disk contract changes in a future release.
+ */
+
 const fs = require("node:fs/promises");
 const path = require("node:path");
 const { sha256File } = require("./sha");
@@ -17,6 +25,8 @@ async function writeManifest(root, manifest) {
 }
 
 async function verifyManifest(root, manifest) {
+  // Return per-file results instead of throwing so callers can print every
+  // mismatch before choosing the final process exit code.
   const results = [];
   for (const runtime of Object.keys(manifest.runtimes || {})) {
     for (const file of manifest.runtimes[runtime].files || []) {

--- a/cli/utils/paths.js
+++ b/cli/utils/paths.js
@@ -1,3 +1,11 @@
+/**
+ * cli/utils/paths.js
+ *
+ * Centralizes cache path construction. `--out` is resolved relative to the
+ * user's current working directory, and each model then gets runtime-specific
+ * subfolders under <out>/<model>/.
+ */
+
 const path = require("node:path");
 
 function resolveOutDir(outDir) {

--- a/cli/utils/paths.js
+++ b/cli/utils/paths.js
@@ -1,0 +1,15 @@
+const path = require("node:path");
+
+function resolveOutDir(outDir) {
+  return path.resolve(process.cwd(), outDir || "ml5-models");
+}
+
+function modelRoot(outDir, modelName) {
+  return path.join(resolveOutDir(outDir), modelName);
+}
+
+function runtimeDir(outDir, modelName, runtime) {
+  return path.join(modelRoot(outDir, modelName), runtime);
+}
+
+module.exports = { resolveOutDir, modelRoot, runtimeDir };

--- a/cli/utils/progress.js
+++ b/cli/utils/progress.js
@@ -1,3 +1,10 @@
+/**
+ * cli/utils/progress.js
+ *
+ * Quiet-aware logging helper. Errors are thrown by callers instead of routed
+ * through this helper, so `--quiet` suppresses progress without hiding failures.
+ */
+
 function log(message, quiet) {
   if (!quiet) console.log(message);
 }

--- a/cli/utils/progress.js
+++ b/cli/utils/progress.js
@@ -1,0 +1,5 @@
+function log(message, quiet) {
+  if (!quiet) console.log(message);
+}
+
+module.exports = { log };

--- a/cli/utils/sha.js
+++ b/cli/utils/sha.js
@@ -1,0 +1,18 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+
+function sha256File(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+function sha256Buffer(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+module.exports = { sha256File, sha256Buffer };

--- a/cli/utils/sha.js
+++ b/cli/utils/sha.js
@@ -1,9 +1,17 @@
+/**
+ * cli/utils/sha.js
+ *
+ * SHA-256 helpers used by manifest generation and verification.
+ */
+
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 
 function sha256File(filePath) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash("sha256");
+    // Stream file contents so large MediaPipe .data / .wasm files are not
+    // loaded into memory at once.
     const stream = fs.createReadStream(filePath);
     stream.on("error", reject);
     stream.on("data", (chunk) => hash.update(chunk));

--- a/cli/utils/size.js
+++ b/cli/utils/size.js
@@ -1,0 +1,7 @@
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+module.exports = { formatBytes };

--- a/cli/utils/size.js
+++ b/cli/utils/size.js
@@ -1,3 +1,9 @@
+/**
+ * cli/utils/size.js
+ *
+ * Tiny human-readable byte formatter for CLI progress and diagnostics.
+ */
+
 function formatBytes(bytes) {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -1,3 +1,11 @@
+/**
+ * cli/verify.js
+ *
+ * Implements `ml5 cache verify <model> [--out <dir>]` by reading the model's
+ * manifest, recomputing size + SHA-256 for each recorded file, and setting a
+ * non-zero exit code if any file is missing or changed.
+ */
+
 const path = require("node:path");
 const { resolveOutDir } = require("./utils/paths");
 const { readManifest, verifyManifest } = require("./utils/manifest");
@@ -5,6 +13,9 @@ const { readManifest, verifyManifest } = require("./utils/manifest");
 async function verify(args) {
   const outIndex = args.indexOf("--out");
   const out = resolveOutDir(outIndex >= 0 ? args[outIndex + 1] : "ml5-models");
+  // TODO: Replace this lightweight positional parsing with a shared parser.
+  // It matches clear.js for now, but a real parser would avoid surprising
+  // behavior when flags and model names are interleaved unusually.
   const model = args.find((arg) => !arg.startsWith("--") && arg !== (outIndex >= 0 ? args[outIndex + 1] : undefined));
   if (!model) throw new Error("Usage: ml5 cache verify <model>");
   const root = path.join(out, model.toLowerCase());

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -1,0 +1,18 @@
+const path = require("node:path");
+const { resolveOutDir } = require("./utils/paths");
+const { readManifest, verifyManifest } = require("./utils/manifest");
+
+async function verify(args) {
+  const outIndex = args.indexOf("--out");
+  const out = resolveOutDir(outIndex >= 0 ? args[outIndex + 1] : "ml5-models");
+  const model = args.find((arg) => !arg.startsWith("--") && arg !== (outIndex >= 0 ? args[outIndex + 1] : undefined));
+  if (!model) throw new Error("Usage: ml5 cache verify <model>");
+  const root = path.join(out, model.toLowerCase());
+  const manifest = await readManifest(root);
+  if (!manifest) throw new Error(`No manifest found for ${model}`);
+  const results = await verifyManifest(root, manifest);
+  results.forEach((result) => console.log(`${result.ok ? "✓" : "✗"} ${result.path}`));
+  if (results.some((result) => !result.ok)) process.exitCode = 1;
+}
+
+module.exports = { verify };

--- a/docs/manual-model-setup/README.md
+++ b/docs/manual-model-setup/README.md
@@ -2,6 +2,9 @@
 
 Normally, ml5 downloads model files from the internet when your sketch starts. These guides show how to download those files yourself, put them next to your sketch, and use `modelPath` so your project can keep working without WiFi.
 
+> **💡 If you can run Node, prefer the CLI.**
+> `npx ml5 cache prefetch <model>` (today: `node bin/ml5.js cache prefetch <model>`) does all of this for you and produces a verifiable manifest. These manual instructions exist as a fallback for environments where Node is not available — see [`../offline-mode.md`](../offline-mode.md) for the recommended path.
+
 This is the slower, more hands-on path. If you are comfortable using a terminal, the CLI guide in [`../offline-mode.md`](../offline-mode.md) is usually easier.
 
 ## Which guide should I use?

--- a/docs/manual-model-setup/README.md
+++ b/docs/manual-model-setup/README.md
@@ -1,0 +1,33 @@
+# Manual model setup for offline sketches
+
+Normally, ml5 downloads model files from the internet when your sketch starts. These guides show how to download those files yourself, put them next to your sketch, and use `modelPath` so your project can keep working without WiFi.
+
+This is the slower, more hands-on path. If you are comfortable using a terminal, the CLI guide in [`../offline-mode.md`](../offline-mode.md) is usually easier.
+
+## Which guide should I use?
+
+| If this sounds like you... | Start here |
+| --- | --- |
+| I want the easiest setup and I can use a terminal. | [`../offline-mode.md`](../offline-mode.md) |
+| I do not want to use a terminal, or I want to understand every file. | One of the manual guides below. |
+| I am using the p5.js Web Editor. | Local bundled files are not a good fit there — use normal CDN loading, or browser caching when available. |
+
+## Pick your model
+
+- [HandPose manual setup](./manual-setup-handpose.md)
+- [FaceMesh manual setup](./manual-setup-facemesh.md)
+- [BodyPose manual setup](./manual-setup-bodypose.md)
+
+## Reference pages
+
+- [Where to download every model file](./where-to-download-models.md)
+- [Troubleshooting](./troubleshooting.md)
+
+## A few helpful words
+
+- **Model**: the files that contain the learned machine learning behavior.
+- **Runtime**: the tool that runs the model in the browser. These guides cover **TFJS** and **MediaPipe**.
+- **TFJS**: TensorFlow.js. This is the default path for many ml5 models.
+- **MediaPipe**: Google's browser-ready solution files. These usually include `.js`, `.wasm`, `.data`, `.binarypb`, and `.tflite` files.
+- **Shard**: a `.bin` file that stores part of a TFJS model's weights. A `model.json` file tells the browser which shard files it needs.
+- **`modelPath`**: the ml5 option that tells a model where your local files are.

--- a/docs/manual-model-setup/manual-setup-bodypose.md
+++ b/docs/manual-model-setup/manual-setup-bodypose.md
@@ -1,0 +1,150 @@
+# Manual setup: BodyPose
+
+This guide shows how to run a BodyPose sketch with model files stored beside your project.
+
+BodyPose has two model families:
+
+- **MoveNet**: the ml5 default. This guide recommends MoveNet TFJS for beginners.
+- **BlazePose**: available through TFJS or MediaPipe. It has more options and more files.
+
+## What you will end up with
+
+```text
+my-sketch/
+  index.html
+  sketch.js
+  ml5-models/
+    bodypose/
+      tfjs/
+        model/
+          model.json
+          group*.bin
+        detector/
+          model.json
+          group*.bin
+        landmark/
+          model.json
+          group*.bin
+      mediapipe/
+        pose_web.binarypb
+        pose.js
+        pose_landmark_full.tflite
+        ...
+```
+
+You only need the folder for the path you choose. In your sketch, point `modelPath` at the model root (`./ml5-models/bodypose`), not at the `tfjs/` or `mediapipe/` subfolder.
+
+```js
+// MoveNet TFJS, the BodyPose default
+ml5.bodyPose({ modelPath: "./ml5-models/bodypose" });
+
+// BlazePose TFJS
+ml5.bodyPose({ modelName: "BlazePose", modelPath: "./ml5-models/bodypose" });
+
+// BlazePose MediaPipe, if you downloaded the mediapipe/ files
+ml5.bodyPose({ modelName: "BlazePose", runtime: "mediapipe", modelPath: "./ml5-models/bodypose" });
+```
+
+## Path A: MoveNet TFJS, recommended for beginners
+
+Create this folder:
+
+```text
+ml5-models/bodypose/tfjs/model/
+```
+
+Download:
+
+- [MoveNet model.json](https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1/model.json?tfjs-format=file) → save as `ml5-models/bodypose/tfjs/model/model.json`
+
+Then open `model.json` in a text editor. Find `weightsManifest`, then download every `.bin` file listed in `paths`. Save each `.bin` file in `ml5-models/bodypose/tfjs/model/`.
+
+Use this in your sketch:
+
+```js
+ml5.bodyPose({ modelPath: "./ml5-models/bodypose" });
+```
+
+## Path B: BlazePose TFJS
+
+Create these folders:
+
+```text
+ml5-models/bodypose/tfjs/detector/
+ml5-models/bodypose/tfjs/landmark/
+```
+
+Download:
+
+- [BlazePose detector model.json](https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1/model.json?tfjs-format=file) → save as `ml5-models/bodypose/tfjs/detector/model.json`
+- [BlazePose landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2/model.json?tfjs-format=file) → save as `ml5-models/bodypose/tfjs/landmark/model.json`
+
+Then open each `model.json` file, find `weightsManifest`, and download every `.bin` shard listed in `paths`.
+
+Use this in your sketch:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", modelPath: "./ml5-models/bodypose" });
+```
+
+## Path C: BlazePose MediaPipe
+
+Create this folder:
+
+```text
+ml5-models/bodypose/mediapipe/
+```
+
+Download these shared files into that folder:
+
+- [pose_web.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_web.binarypb)
+- [pose.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose.js)
+- [pose_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_packed_assets.data)
+- [pose_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_packed_assets_loader.js)
+- [pose_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.js)
+- [pose_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.wasm)
+- [pose_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.data)
+- [pose_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_wasm_bin.js)
+- [pose_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_wasm_bin.wasm)
+
+Then choose one landmark model:
+
+- Lite, smaller and usually faster: [pose_landmark_lite.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_lite.tflite)
+- Full, balanced default: [pose_landmark_full.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_full.tflite)
+- Heavy, largest and usually most accurate: [pose_landmark_heavy.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_heavy.tflite)
+
+You can also browse the files at [jsdelivr's `@mediapipe/pose` page](https://www.jsdelivr.com/package/npm/@mediapipe/pose).
+
+Use this in your sketch:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", runtime: "mediapipe", modelPath: "./ml5-models/bodypose" });
+```
+
+## Run your sketch locally
+
+Do not open `index.html` with `file://`. Use a local server.
+
+The friendliest option for many beginners is the **Live Server** extension in VS Code. Open your sketch folder, click **Go Live**, then open the local URL it gives you.
+
+Or, from your sketch folder, run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000`.
+
+## Verify it loaded locally
+
+Open DevTools → Network, reload, and check that model files load from `localhost`. They should not load from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+## See also
+
+- Example: [`../../examples/bodyPose-keypoints-offline-local-model-cli/`](../../examples/bodyPose-keypoints-offline-local-model-cli/)
+- Full file reference: [`where-to-download-models.md`](./where-to-download-models.md)
+- Troubleshooting: [`troubleshooting.md`](./troubleshooting.md)
+
+## License note
+
+MediaPipe assets are distributed by Google under Apache-2.0. TFJS model weights are distributed by Google through TFHub/Kaggle model hosting. Keep upstream attribution with projects that redistribute `ml5-models/`.

--- a/docs/manual-model-setup/manual-setup-facemesh.md
+++ b/docs/manual-model-setup/manual-setup-facemesh.md
@@ -1,0 +1,119 @@
+# Manual setup: FaceMesh
+
+This guide shows how to run a FaceMesh sketch with model files stored beside your project.
+
+## What you will end up with
+
+```text
+my-sketch/
+  index.html
+  sketch.js
+  ml5-models/
+    facemesh/
+      tfjs/
+        detector/
+          model.json
+          group*.bin
+        landmark/
+          model.json
+          group*.bin
+      mediapipe/
+        face_mesh.binarypb
+        face_mesh.js
+        ...
+```
+
+You do not need both `tfjs/` and `mediapipe/`. Pick one path below. In your sketch, point `modelPath` at the model root (`./ml5-models/facemesh`), not at the `tfjs/` or `mediapipe/` subfolder.
+
+## Pick a runtime
+
+- **TFJS** is recommended if you are unsure.
+- **MediaPipe** is useful if you specifically want FaceMesh's MediaPipe runtime. It has more files to download.
+
+```js
+// TFJS, the default for local model roots
+ml5.faceMesh({ ...options, modelPath: "./ml5-models/facemesh" });
+
+// MediaPipe, if you downloaded the mediapipe/ files
+ml5.faceMesh({ ...options, runtime: "mediapipe", modelPath: "./ml5-models/facemesh" });
+```
+
+For a first manual setup, keep `refineLandmarks: false`. The refined landmarks option may require extra attention-model assets that are easier to manage with the CLI.
+
+## Path A: TFJS, recommended for beginners
+
+Create these folders:
+
+```text
+ml5-models/facemesh/tfjs/detector/
+ml5-models/facemesh/tfjs/landmark/
+```
+
+Download the two `model.json` files:
+
+- [Detector model.json](https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1/model.json?tfjs-format=file) → save as `ml5-models/facemesh/tfjs/detector/model.json`
+- [Landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1/model.json?tfjs-format=file) → save as `ml5-models/facemesh/tfjs/landmark/model.json`
+
+Then open each `model.json` file in a text editor. Find `weightsManifest`, then download every `.bin` file listed in `paths`. Save each `.bin` file in the same folder as the `model.json` that mentioned it.
+
+Use this in your sketch:
+
+```js
+ml5.faceMesh({ ...options, modelPath: "./ml5-models/facemesh" });
+```
+
+## Path B: MediaPipe
+
+Create this folder:
+
+```text
+ml5-models/facemesh/mediapipe/
+```
+
+Download these files into that folder:
+
+- [face_mesh.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh.binarypb)
+- [face_mesh.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh.js)
+- [face_mesh_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_packed_assets.data)
+- [face_mesh_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_packed_assets_loader.js)
+- [face_mesh_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.js)
+- [face_mesh_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.wasm)
+- [face_mesh_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.data)
+- [face_mesh_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_wasm_bin.js)
+- [face_mesh_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_wasm_bin.wasm)
+
+You can also browse the files at [jsdelivr's `@mediapipe/face_mesh` page](https://www.jsdelivr.com/package/npm/@mediapipe/face_mesh).
+
+Use this in your sketch:
+
+```js
+ml5.faceMesh({ ...options, runtime: "mediapipe", modelPath: "./ml5-models/facemesh" });
+```
+
+## Run your sketch locally
+
+Do not open `index.html` with `file://`. Use a local server.
+
+The friendliest option for many beginners is the **Live Server** extension in VS Code. Open your sketch folder, click **Go Live**, then open the local URL it gives you.
+
+Or, from your sketch folder, run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000`.
+
+## Verify it loaded locally
+
+Open DevTools → Network, reload, and check that model files load from `localhost`. They should not load from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+## See also
+
+- Example: [`../../examples/faceMesh-keypoints-offline-local-model-cli/`](../../examples/faceMesh-keypoints-offline-local-model-cli/)
+- Full file reference: [`where-to-download-models.md`](./where-to-download-models.md)
+- Troubleshooting: [`troubleshooting.md`](./troubleshooting.md)
+
+## License note
+
+MediaPipe assets are distributed by Google under Apache-2.0. TFJS model weights are distributed by Google through TFHub/Kaggle model hosting. Keep upstream attribution with projects that redistribute `ml5-models/`.

--- a/docs/manual-model-setup/manual-setup-handpose.md
+++ b/docs/manual-model-setup/manual-setup-handpose.md
@@ -1,0 +1,123 @@
+# Manual setup: HandPose
+
+This guide shows how to run a HandPose sketch with model files stored beside your project.
+
+## What you will end up with
+
+```text
+my-sketch/
+  index.html
+  sketch.js
+  ml5-models/
+    handpose/
+      tfjs/
+        detector/
+          model.json
+          group*.bin
+        landmark/
+          model.json
+          group*.bin
+      mediapipe/
+        hands.binarypb
+        hands.js
+        hand_landmark_full.tflite
+        ...
+```
+
+You do not need both `tfjs/` and `mediapipe/`. Pick one path below. In your sketch, point `modelPath` at the model root (`./ml5-models/handpose`), not at the `tfjs/` or `mediapipe/` subfolder.
+
+## Pick a runtime
+
+- **TFJS** is recommended if you are unsure. It is the default path and usually has fewer files to manage.
+- **MediaPipe** uses more files, including `.wasm`, `.data`, `.binarypb`, and `.tflite` files. It can be a good choice if you specifically want the MediaPipe runtime.
+
+```js
+// TFJS, the default for local model roots
+ml5.handPose({ modelPath: "./ml5-models/handpose" });
+
+// MediaPipe, if you downloaded the mediapipe/ files
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+## Path A: TFJS, recommended for beginners
+
+Create these folders:
+
+```text
+ml5-models/handpose/tfjs/detector/
+ml5-models/handpose/tfjs/landmark/
+```
+
+Download the two `model.json` files:
+
+- [Detector model.json](https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1/model.json?tfjs-format=file) → save as `ml5-models/handpose/tfjs/detector/model.json`
+- [Landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1/model.json?tfjs-format=file) → save as `ml5-models/handpose/tfjs/landmark/model.json`
+
+Then open each `model.json` file in a text editor. Find `weightsManifest`, then download every `.bin` file listed in `paths`. Save each `.bin` file in the same folder as the `model.json` that mentioned it.
+
+Use this in your sketch:
+
+```js
+ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+## Path B: MediaPipe
+
+Create this folder:
+
+```text
+ml5-models/handpose/mediapipe/
+```
+
+Download these shared files into that folder:
+
+- [hands.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.binarypb)
+- [hands.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.js)
+- [hands_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_packed_assets.data)
+- [hands_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_packed_assets_loader.js)
+- [hands_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.js)
+- [hands_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.wasm)
+- [hands_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.data)
+- [hands_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_wasm_bin.js)
+- [hands_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_wasm_bin.wasm)
+
+Then choose one landmark model:
+
+- Smaller: [hand_landmark_lite.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hand_landmark_lite.tflite)
+- Default/full: [hand_landmark_full.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hand_landmark_full.tflite)
+
+You can also browse the files at [jsdelivr's `@mediapipe/hands` page](https://www.jsdelivr.com/package/npm/@mediapipe/hands).
+
+Use this in your sketch:
+
+```js
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+## Run your sketch locally
+
+Do not open `index.html` with `file://`. Use a local server.
+
+The friendliest option for many beginners is the **Live Server** extension in VS Code. Open your sketch folder, click **Go Live**, then open the local URL it gives you.
+
+Or, from your sketch folder, run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000`.
+
+## Verify it loaded locally
+
+Open DevTools → Network, reload, and check that model files load from `localhost`. They should not load from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+## See also
+
+- Example: [`../../examples/handPose-keypoints-offline-local-model-cli/`](../../examples/handPose-keypoints-offline-local-model-cli/)
+- Full file reference: [`where-to-download-models.md`](./where-to-download-models.md)
+- Troubleshooting: [`troubleshooting.md`](./troubleshooting.md)
+
+## License note
+
+MediaPipe assets are distributed by Google under Apache-2.0. TFJS model weights are distributed by Google through TFHub/Kaggle model hosting. Keep upstream attribution with projects that redistribute `ml5-models/`.

--- a/docs/manual-model-setup/troubleshooting.md
+++ b/docs/manual-model-setup/troubleshooting.md
@@ -1,0 +1,80 @@
+# Troubleshooting manual model setup
+
+Manual setup is mostly about putting the exact files in the exact folders your sketch expects. If something is not working, start with the Network tab in your browser's developer tools.
+
+## My file saved as `model.json.txt`
+
+Some systems hide file extensions or add `.txt` automatically. The file must be named exactly `model.json`.
+
+On Windows, turn on **View → File name extensions** in File Explorer, then rename `model.json.txt` to `model.json`.
+
+## I see a 404 in the Network tab
+
+A 404 means the browser asked for a file, but your local server could not find it.
+
+Check:
+
+- Is the file actually in your `ml5-models/` folder?
+- Is the filename exactly the same, including underscores and capitalization?
+- Is `ml5-models/` next to the `index.html` file that opened in the browser?
+- Does your `modelPath` match the folder name?
+
+## The page loads, but nothing is detected
+
+This is often a runtime mismatch.
+
+For TFJS files, use a model root such as:
+
+```js
+ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+For MediaPipe files, include the MediaPipe runtime option when the model supports it:
+
+```js
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+Also make sure your webcam permission is allowed and your face, hand, or body is visible in the video.
+
+## I see MIME type or `application/octet-stream` errors
+
+Do not open the page with `file://`. Use a local server, such as VS Code Live Server or:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000`.
+
+## Files still load from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`
+
+That usually means ml5 could not find your local files and fell back to its normal online URLs.
+
+Check the Network tab for the first local 404. Fix that missing file or folder first.
+
+## The `model.json` mentions files I did not download
+
+Open `model.json` and look for `weightsManifest`. Every filename in the `paths` list must be downloaded into the same folder as that `model.json`.
+
+Sometimes a model has one shard. Sometimes it has several. Trust the `model.json` you downloaded.
+
+## The shard count is different from the docs
+
+Model hosts can change how files are split. The important rule is: download every shard listed in your `model.json`.
+
+## Can I use this in the p5.js Web Editor?
+
+The p5.js Web Editor is wonderful for sharing sketches, but it is not a good place to bundle large local model folders. For Web Editor sketches, use the normal online loading path, or browser caching if available.
+
+## My sketch is in a subfolder. Where does `ml5-models/` go?
+
+`modelPath` is relative to the HTML page that loads your sketch. If your browser opens `my-sketch/index.html`, then `./ml5-models/handpose` means:
+
+```text
+my-sketch/
+  index.html
+  sketch.js
+  ml5-models/
+    handpose/
+```

--- a/docs/manual-model-setup/where-to-download-models.md
+++ b/docs/manual-model-setup/where-to-download-models.md
@@ -1,0 +1,126 @@
+# Where to download model files
+
+This page lists the model files used by the manual setup guides. The links are intentionally explicit so you can see exactly what your sketch needs.
+
+Tip: for linked files, you can click the link or right-click and choose **Save Link As...**. Make sure the saved filename matches the filename shown in the guide.
+
+## TFJS models
+
+TFJS models start with a `model.json` file. That JSON file lists one or more weight shard files, usually named something like `group1-shard1of1.bin`.
+
+To download a TFJS model manually:
+
+1. Open the `model.json` link below.
+2. Save it as `model.json` in the folder shown.
+3. Open the saved `model.json` in a text editor.
+4. Find `weightsManifest`, then look for the `paths` list.
+5. Download every `.bin` file listed in `paths` from the same folder URL as the `model.json`.
+
+The `?tfjs-format=file` part is important for TFHub links. It asks TFHub for browser-friendly files instead of a webpage.
+
+### HandPose TFJS
+
+| Piece | Download `model.json` from | Put it here |
+| --- | --- | --- |
+| Detector | [handpose detector model.json](https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1/model.json?tfjs-format=file) | `ml5-models/handpose/tfjs/detector/model.json` |
+| Landmark | [handpose landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1/model.json?tfjs-format=file) | `ml5-models/handpose/tfjs/landmark/model.json` |
+
+### FaceMesh TFJS
+
+| Piece | Download `model.json` from | Put it here |
+| --- | --- | --- |
+| Detector | [face detection model.json](https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1/model.json?tfjs-format=file) | `ml5-models/facemesh/tfjs/detector/model.json` |
+| Landmark | [face mesh landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1/model.json?tfjs-format=file) | `ml5-models/facemesh/tfjs/landmark/model.json` |
+
+### BodyPose TFJS
+
+| Piece | Download `model.json` from | Put it here |
+| --- | --- | --- |
+| MoveNet | [MoveNet multipose lightning model.json](https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1/model.json?tfjs-format=file) | `ml5-models/bodypose/tfjs/model/model.json` |
+| BlazePose detector | [BlazePose detector model.json](https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1/model.json?tfjs-format=file) | `ml5-models/bodypose/tfjs/detector/model.json` |
+| BlazePose landmark | [BlazePose landmark model.json](https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2/model.json?tfjs-format=file) | `ml5-models/bodypose/tfjs/landmark/model.json` |
+
+## MediaPipe versions
+
+These docs were written against the MediaPipe package versions currently installed by this repository:
+
+| Model | Package | Version snapshot | npm page |
+| --- | --- | --- | --- |
+| HandPose | `@mediapipe/hands` | `0.4.1675469240` | [npm](https://www.npmjs.com/package/@mediapipe/hands) |
+| FaceMesh | `@mediapipe/face_mesh` | `0.4.1633559619` | [npm](https://www.npmjs.com/package/@mediapipe/face_mesh) |
+| BodyPose / BlazePose | `@mediapipe/pose` | `0.5.1675469404` | [npm](https://www.npmjs.com/package/@mediapipe/pose) |
+
+For best compatibility with ml5, use the versions listed in ml5's `package.json`. You can also check npm for newer versions, but newer files may not always match the version of ml5 you are using.
+
+The bare CDN pattern is:
+
+```text
+https://cdn.jsdelivr.net/npm/@mediapipe/<package>@<version>/<file>
+```
+
+You can also use the jsdelivr file browser:
+
+- [Browse `@mediapipe/hands`](https://www.jsdelivr.com/package/npm/@mediapipe/hands)
+- [Browse `@mediapipe/face_mesh`](https://www.jsdelivr.com/package/npm/@mediapipe/face_mesh)
+- [Browse `@mediapipe/pose`](https://www.jsdelivr.com/package/npm/@mediapipe/pose)
+
+## HandPose MediaPipe files
+
+Put these files in `ml5-models/handpose/mediapipe/`.
+
+Shared files:
+
+- [hands.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.binarypb)
+- [hands.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands.js)
+- [hands_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_packed_assets.data)
+- [hands_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_packed_assets_loader.js)
+- [hands_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.js)
+- [hands_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.wasm)
+- [hands_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_simd_wasm_bin.data)
+- [hands_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_wasm_bin.js)
+- [hands_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hands_solution_wasm_bin.wasm)
+
+Choose one landmark model:
+
+- Lite, smaller and usually faster: [hand_landmark_lite.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hand_landmark_lite.tflite)
+- Full, larger and usually more accurate: [hand_landmark_full.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/hands@0.4.1675469240/hand_landmark_full.tflite)
+
+## FaceMesh MediaPipe files
+
+Put these files in `ml5-models/facemesh/mediapipe/`.
+
+- [face_mesh.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh.binarypb)
+- [face_mesh.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh.js)
+- [face_mesh_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_packed_assets.data)
+- [face_mesh_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_packed_assets_loader.js)
+- [face_mesh_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.js)
+- [face_mesh_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.wasm)
+- [face_mesh_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_simd_wasm_bin.data)
+- [face_mesh_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_wasm_bin.js)
+- [face_mesh_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh@0.4.1633559619/face_mesh_solution_wasm_bin.wasm)
+
+## BodyPose BlazePose MediaPipe files
+
+Put these files in `ml5-models/bodypose/mediapipe/`.
+
+Shared files:
+
+- [pose_web.binarypb](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_web.binarypb)
+- [pose.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose.js)
+- [pose_solution_packed_assets.data](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_packed_assets.data)
+- [pose_solution_packed_assets_loader.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_packed_assets_loader.js)
+- [pose_solution_simd_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.js)
+- [pose_solution_simd_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.wasm)
+- [pose_solution_simd_wasm_bin.data](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_simd_wasm_bin.data)
+- [pose_solution_wasm_bin.js](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_wasm_bin.js)
+- [pose_solution_wasm_bin.wasm](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_solution_wasm_bin.wasm)
+
+Choose one landmark model:
+
+- Lite, smaller and usually faster: [pose_landmark_lite.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_lite.tflite)
+- Full, balanced default: [pose_landmark_full.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_full.tflite)
+- Heavy, largest and usually most accurate: [pose_landmark_heavy.tflite](https://cdn.jsdelivr.net/npm/@mediapipe/pose@0.5.1675469404/pose_landmark_heavy.tflite)
+
+## Licensing and attribution
+
+MediaPipe assets are distributed by Google under Apache-2.0. TFJS model weights are distributed by Google through TFHub/Kaggle model hosting. When you share a project with bundled `ml5-models/`, keep upstream license and attribution information with your project.

--- a/docs/model-urls.md
+++ b/docs/model-urls.md
@@ -1,0 +1,13 @@
+# Model URL reference
+
+This file is the human-readable companion to `src/utils/modelRegistry.js`.
+
+For a beginner-friendly walkthrough with manual download instructions, see [`manual-model-setup/where-to-download-models.md`](./manual-model-setup/where-to-download-models.md).
+
+- HandPose TFJS detector: `https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1`
+- HandPose TFJS landmark: `https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1`
+- FaceMesh TFJS detector: `https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1`
+- FaceMesh TFJS landmark: `https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1`
+- BodyPose MoveNet TFJS: `https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1`
+
+MediaPipe files are copied from the installed `@mediapipe/hands`, `@mediapipe/face_mesh`, and `@mediapipe/pose` packages. The concrete file lists live in `src/utils/modelRegistry.js`.

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,0 +1,69 @@
+# Offline mode
+
+Use offline mode when a sketch needs to keep working on `localhost` without internet access, including after browser restarts.
+
+New to local model files or prefer not to use the CLI? See the beginner-friendly [manual model setup guides](./manual-model-setup/README.md).
+
+## Quick start
+
+```bash
+node bin/ml5.js cache prefetch handpose
+```
+
+Run this from the ml5-next-gen repo root. Once the CLI is published to npm, this becomes `npx ml5 cache prefetch handpose`.
+
+Then point `modelPath` at the model root:
+
+```js
+let handPose = ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+The CLI writes a per-runtime layout:
+
+```text
+ml5-models/handpose/
+  manifest.json
+  tfjs/
+  mediapipe/
+```
+
+Point `modelPath` at the **model root**: the folder that contains `manifest.json`, such as `./ml5-models/handpose`. Do not point at a runtime subfolder like `./ml5-models/handpose/tfjs`.
+
+When `modelPath` points at a prefetched model root, ml5 uses the TFJS files by default. To force MediaPipe:
+
+```js
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+Advanced: pointing directly at a leaf folder containing `model.json` only works for single-model TFJS layouts, such as BodyPose MoveNet. HandPose, FaceMesh, and BodyPose BlazePose have separate detector and landmark models, so they should use the model-root path.
+
+## Examples
+
+These examples show the local model CLI workflow end to end:
+
+- `examples/handPose-keypoints-offline-local-model-cli/`
+- `examples/faceMesh-keypoints-offline-local-model-cli/`
+- `examples/bodyPose-keypoints-offline-local-model-cli/`
+
+## CLI commands
+
+```bash
+node bin/ml5.js cache prefetch handpose facemesh bodypose
+node bin/ml5.js cache prefetch bodypose --runtime mediapipe --variant full
+node bin/ml5.js cache list
+node bin/ml5.js cache verify handpose
+node bin/ml5.js cache clear handpose
+node bin/ml5.js cache models
+```
+
+`prefetch` downloads TFJS `model.json` files and shards, copies MediaPipe assets from ml5's installed dependencies, and records SHA-256 checksums in `manifest.json`.
+
+## Known limitations
+
+- Do not open sketches with `file://`; use a local web server.
+- Strict Content Security Policy rules can block MediaPipe's script loading.
+- p5.js Web Editor users cannot run the CLI, so they should keep using CDN loading or IndexedDB caching.
+
+## Licensing
+
+MediaPipe assets are distributed by Google under Apache-2.0. TFJS model weights are distributed by Google through TFHub/Kaggle model hosting. When redistributing a sketch with bundled `ml5-models/`, retain upstream license and attribution information.

--- a/examples/bodyPose-keypoints-offline-local-model-cli/.gitignore
+++ b/examples/bodyPose-keypoints-offline-local-model-cli/.gitignore
@@ -1,0 +1,1 @@
+ml5-models/

--- a/examples/bodyPose-keypoints-offline-local-model-cli/INSTRUCTIONS.md
+++ b/examples/bodyPose-keypoints-offline-local-model-cli/INSTRUCTIONS.md
@@ -1,0 +1,63 @@
+# Running this BodyPose example offline
+
+Follow these steps from this example folder.
+
+## 1. Download the local model files
+
+This example uses BodyPose with the default MoveNet model. To download only the TFJS files needed by this sketch, run:
+
+```bash
+node ../../bin/ml5.js cache prefetch bodypose --runtime tfjs
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch bodypose --runtime tfjs`.
+
+If you want both MoveNet and BlazePose files available locally, run:
+
+```bash
+node ../../bin/ml5.js cache prefetch bodypose
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch bodypose`.
+
+This creates `./ml5-models/bodypose/` next to `index.html`. The sketch loads MoveNet with:
+
+```js
+ml5.bodyPose({ modelPath: "./ml5-models/bodypose" });
+```
+
+Use the model root (`./ml5-models/bodypose`), not the `tfjs/` or `mediapipe/` subfolder. To use local BlazePose TFJS instead of MoveNet:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", modelPath: "./ml5-models/bodypose" });
+```
+
+To force local BlazePose MediaPipe:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", runtime: "mediapipe", modelPath: "./ml5-models/bodypose" });
+```
+
+## 2. Start a local web server
+
+Do not open `index.html` with `file://`. From this folder, run one of:
+
+```bash
+python3 -m http.server 8000
+```
+
+or:
+
+```bash
+bunx serve .
+```
+
+Then open `http://localhost:8000` or the URL printed by `serve`.
+
+## 3. Verify it is loading locally
+
+Open DevTools → Network, reload the page, and confirm model files load from `localhost`, not from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+For more options, see [`../../docs/offline-mode.md`](../../docs/offline-mode.md).
+
+Don't want to use the terminal? See [`../../docs/manual-model-setup/manual-setup-bodypose.md`](../../docs/manual-model-setup/manual-setup-bodypose.md) for a fully manual walkthrough.

--- a/examples/bodyPose-keypoints-offline-local-model-cli/README.md
+++ b/examples/bodyPose-keypoints-offline-local-model-cli/README.md
@@ -1,0 +1,39 @@
+# BodyPose keypoints — offline (local model via CLI)
+
+This example tracks body keypoints from a webcam with the default BodyPose **MoveNet** model while loading model files from this folder instead of the network.
+
+Run this once from this example folder:
+
+```bash
+node ../../bin/ml5.js cache prefetch bodypose
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch bodypose`.
+
+The command creates `./ml5-models/bodypose/` with local TFJS and MediaPipe files plus a `manifest.json` integrity file. The sketch uses:
+
+```js
+ml5.bodyPose({ modelPath: "./ml5-models/bodypose" });
+```
+
+Point `modelPath` at the model root (`./ml5-models/bodypose`), not at `tfjs/` or `mediapipe/`. This sketch uses MoveNet, which loads from the local TFJS files. If you only need this MoveNet sketch, use:
+
+```bash
+node ../../bin/ml5.js cache prefetch bodypose --runtime tfjs
+```
+
+To try the local BlazePose TFJS files instead, switch the sketch to:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", modelPath: "./ml5-models/bodypose" });
+```
+
+To force the local BlazePose MediaPipe runtime, use:
+
+```js
+ml5.bodyPose({ modelName: "BlazePose", runtime: "mediapipe", modelPath: "./ml5-models/bodypose" });
+```
+
+To verify offline loading, open DevTools → Network, reload, and confirm the model files come from `localhost` instead of `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+See also: [`../../docs/offline-mode.md`](../../docs/offline-mode.md) for advanced CLI flags, verification, and output directory options.

--- a/examples/bodyPose-keypoints-offline-local-model-cli/index.html
+++ b/examples/bodyPose-keypoints-offline-local-model-cli/index.html
@@ -1,0 +1,20 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates pose tracking on live video through ml5.bodyPose with MoveNet model.
+-->
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>ml5.js bodyPose Detection Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.10/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/bodyPose-keypoints-offline-local-model-cli/sketch.js
+++ b/examples/bodyPose-keypoints-offline-local-model-cli/sketch.js
@@ -1,0 +1,56 @@
+// BodyPose keypoints — offline local model CLI version.
+//
+// Setup once before running this sketch:
+//   node ../../bin/ml5.js cache prefetch bodypose
+// Once published to npm, this becomes: npx ml5 cache prefetch bodypose
+//
+// The CLI saves files into ./ml5-models/bodypose/. Point modelPath at that
+// model root, not at the tfjs/ or mediapipe/ runtime subfolder.
+
+let video;
+let bodyPose;
+let poses = [];
+
+function preload() {
+  // Load the BodyPose MoveNet model from local files. For local BlazePose TFJS,
+  // use: ml5.bodyPose({ modelName: "BlazePose", modelPath: "./ml5-models/bodypose" })
+  bodyPose = ml5.bodyPose({ modelPath: "./ml5-models/bodypose" });
+}
+
+function setup() {
+  createCanvas(640, 480);
+
+  // Create the video and hide it
+  video = createCapture(VIDEO);
+  video.size(640, 480);
+  video.hide();
+
+  // Start detecting poses in the webcam video
+  bodyPose.detectStart(video, gotPoses);
+  console.log("BodyPose (MoveNet) model loaded from local files.");
+}
+
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  // Draw all the tracked landmark points
+  for (let i = 0; i < poses.length; i++) {
+    let pose = poses[i];
+    for (let j = 0; j < pose.keypoints.length; j++) {
+      let keypoint = pose.keypoints[j];
+      // Only draw a circle if the keypoint's confidence is bigger than 0.1
+      if (keypoint.confidence > 0.1) {
+        fill(0, 255, 0);
+        noStroke();
+        circle(keypoint.x, keypoint.y, 10);
+      }
+    }
+  }
+}
+
+// Callback function for when bodyPose outputs data
+function gotPoses(results) {
+  // Save the output to the poses variable
+  poses = results;
+}

--- a/examples/faceMesh-keypoints-offline-local-model-cli/.gitignore
+++ b/examples/faceMesh-keypoints-offline-local-model-cli/.gitignore
@@ -1,0 +1,1 @@
+ml5-models/

--- a/examples/faceMesh-keypoints-offline-local-model-cli/INSTRUCTIONS.md
+++ b/examples/faceMesh-keypoints-offline-local-model-cli/INSTRUCTIONS.md
@@ -1,0 +1,47 @@
+# Running this FaceMesh example offline
+
+Follow these steps from this example folder.
+
+## 1. Download the local model files
+
+```bash
+node ../../bin/ml5.js cache prefetch facemesh
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch facemesh`.
+
+This creates `./ml5-models/facemesh/` next to `index.html`. The sketch loads those files with:
+
+```js
+ml5.faceMesh({ ...options, modelPath: "./ml5-models/facemesh" });
+```
+
+Use the model root (`./ml5-models/facemesh`), not the `tfjs/` or `mediapipe/` subfolder. This uses local TFJS files by default. To force local MediaPipe instead:
+
+```js
+ml5.faceMesh({ ...options, runtime: "mediapipe", modelPath: "./ml5-models/facemesh" });
+```
+
+## 2. Start a local web server
+
+Do not open `index.html` with `file://`. From this folder, run one of:
+
+```bash
+python3 -m http.server 8000
+```
+
+or:
+
+```bash
+bunx serve .
+```
+
+Then open `http://localhost:8000` or the URL printed by `serve`.
+
+## 3. Verify it is loading locally
+
+Open DevTools → Network, reload the page, and confirm model files load from `localhost`, not from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+For more options, see [`../../docs/offline-mode.md`](../../docs/offline-mode.md).
+
+Don't want to use the terminal? See [`../../docs/manual-model-setup/manual-setup-facemesh.md`](../../docs/manual-model-setup/manual-setup-facemesh.md) for a fully manual walkthrough.

--- a/examples/faceMesh-keypoints-offline-local-model-cli/README.md
+++ b/examples/faceMesh-keypoints-offline-local-model-cli/README.md
@@ -1,0 +1,27 @@
+# FaceMesh keypoints — offline (local model via CLI)
+
+This example tracks facial landmarks from a webcam while loading FaceMesh model files from this folder instead of the network.
+
+Run this once from this example folder:
+
+```bash
+node ../../bin/ml5.js cache prefetch facemesh
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch facemesh`.
+
+The command creates `./ml5-models/facemesh/` with local TFJS and MediaPipe files plus a `manifest.json` integrity file. The sketch uses:
+
+```js
+ml5.faceMesh({ ...options, modelPath: "./ml5-models/facemesh" });
+```
+
+Point `modelPath` at the model root (`./ml5-models/facemesh`), not at `tfjs/` or `mediapipe/`. This uses the local TFJS files by default. To force the local MediaPipe runtime instead, use:
+
+```js
+ml5.faceMesh({ ...options, runtime: "mediapipe", modelPath: "./ml5-models/facemesh" });
+```
+
+To verify offline loading, open DevTools → Network, reload, and confirm the model files come from `localhost` instead of `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+See also: [`../../docs/offline-mode.md`](../../docs/offline-mode.md) for advanced CLI flags, verification, and output directory options.

--- a/examples/faceMesh-keypoints-offline-local-model-cli/index.html
+++ b/examples/faceMesh-keypoints-offline-local-model-cli/index.html
@@ -1,0 +1,22 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates face tracking on live video through ml5.faceMesh.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ml5.js faceMesh Webcam Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.10/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/faceMesh-keypoints-offline-local-model-cli/sketch.js
+++ b/examples/faceMesh-keypoints-offline-local-model-cli/sketch.js
@@ -1,0 +1,51 @@
+// FaceMesh keypoints — offline local model CLI version.
+//
+// Setup once before running this sketch:
+//   node ../../bin/ml5.js cache prefetch facemesh
+// Once published to npm, this becomes: npx ml5 cache prefetch facemesh
+//
+// The CLI saves files into ./ml5-models/facemesh/. Point modelPath at that
+// model root, not at the tfjs/ or mediapipe/ runtime subfolder.
+
+let faceMesh;
+let video;
+let faces = [];
+let options = { maxFaces: 1, refineLandmarks: false, flipHorizontal: false };
+
+function preload() {
+  // Load the faceMesh model from local files
+  faceMesh = ml5.faceMesh({ ...options, modelPath: "./ml5-models/facemesh" });
+}
+
+function setup() {
+  createCanvas(640, 480);
+  // Create the webcam video and hide it
+  video = createCapture(VIDEO);
+  video.size(640, 480);
+  video.hide();
+  // Start detecting faces from the webcam video
+  faceMesh.detectStart(video, gotFaces);
+  console.log("FaceMesh model loaded from local files.");
+}
+
+function draw() {
+  // Draw the webcam video
+  image(video, 0, 0, width, height);
+
+  // Draw all the tracked face points
+  for (let i = 0; i < faces.length; i++) {
+    let face = faces[i];
+    for (let j = 0; j < face.keypoints.length; j++) {
+      let keypoint = face.keypoints[j];
+      fill(0, 255, 0);
+      noStroke();
+      circle(keypoint.x, keypoint.y, 5);
+    }
+  }
+}
+
+// Callback function for when faceMesh outputs data
+function gotFaces(results) {
+  // Save the output to the faces variable
+  faces = results;
+}

--- a/examples/handPose-keypoints-offline-local-model-cli/.gitignore
+++ b/examples/handPose-keypoints-offline-local-model-cli/.gitignore
@@ -1,0 +1,1 @@
+ml5-models/

--- a/examples/handPose-keypoints-offline-local-model-cli/INSTRUCTIONS.md
+++ b/examples/handPose-keypoints-offline-local-model-cli/INSTRUCTIONS.md
@@ -1,0 +1,47 @@
+# Running this HandPose example offline
+
+Follow these steps from this example folder.
+
+## 1. Download the local model files
+
+```bash
+node ../../bin/ml5.js cache prefetch handpose
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch handpose`.
+
+This creates `./ml5-models/handpose/` next to `index.html`. The sketch loads those files with:
+
+```js
+ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+Use the model root (`./ml5-models/handpose`), not the `tfjs/` or `mediapipe/` subfolder. This uses local TFJS files by default. To force local MediaPipe instead:
+
+```js
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+## 2. Start a local web server
+
+Do not open `index.html` with `file://`. From this folder, run one of:
+
+```bash
+python3 -m http.server 8000
+```
+
+or:
+
+```bash
+bunx serve .
+```
+
+Then open `http://localhost:8000` or the URL printed by `serve`.
+
+## 3. Verify it is loading locally
+
+Open DevTools → Network, reload the page, and confirm model files load from `localhost`, not from `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+For more options, see [`../../docs/offline-mode.md`](../../docs/offline-mode.md).
+
+Don't want to use the terminal? See [`../../docs/manual-model-setup/manual-setup-handpose.md`](../../docs/manual-model-setup/manual-setup-handpose.md) for a fully manual walkthrough.

--- a/examples/handPose-keypoints-offline-local-model-cli/README.md
+++ b/examples/handPose-keypoints-offline-local-model-cli/README.md
@@ -1,0 +1,25 @@
+# HandPose keypoints — offline (local model via CLI)
+
+Run this once from this example folder:
+
+```bash
+node ../../bin/ml5.js cache prefetch handpose
+```
+
+Once the CLI is published to npm, this becomes `npx ml5 cache prefetch handpose`.
+
+The command creates `./ml5-models/handpose/` with local TFJS and MediaPipe files plus a `manifest.json` integrity file. The sketch uses:
+
+```js
+ml5.handPose({ modelPath: "./ml5-models/handpose" });
+```
+
+Point `modelPath` at the model root (`./ml5-models/handpose`), not at `tfjs/` or `mediapipe/`. This uses the local TFJS files by default. To force the local MediaPipe runtime instead, use:
+
+```js
+ml5.handPose({ runtime: "mediapipe", modelPath: "./ml5-models/handpose" });
+```
+
+To verify offline loading, open DevTools → Network, reload, and confirm the model files come from `localhost` instead of `cdn.jsdelivr.net`, `tfhub.dev`, or `storage.googleapis.com`.
+
+See also: [`../../docs/offline-mode.md`](../../docs/offline-mode.md) for advanced CLI flags, verification, and output directory options.

--- a/examples/handPose-keypoints-offline-local-model-cli/index.html
+++ b/examples/handPose-keypoints-offline-local-model-cli/index.html
@@ -1,0 +1,22 @@
+<!--
+  👋 Hello! This is an ml5.js example made and shared with ❤️.
+  Learn more about the ml5.js project: https://ml5js.org/
+  ml5.js license and Code of Conduct: https://github.com/ml5js/ml5-next-gen/blob/main/LICENSE.md
+
+  This example demonstrates hand tracking on live video through ml5.handPose.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ml5.js handPose Webcam Example</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.10/p5.min.js"></script>
+    <script src="../../dist/ml5.js"></script>
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/examples/handPose-keypoints-offline-local-model-cli/sketch.js
+++ b/examples/handPose-keypoints-offline-local-model-cli/sketch.js
@@ -1,0 +1,40 @@
+// HandPose keypoints — offline local model CLI version.
+//
+// Setup once before running this sketch:
+//   node ../../bin/ml5.js cache prefetch handpose
+// Once published to npm, this becomes: npx ml5 cache prefetch handpose
+//
+// The CLI saves files into ./ml5-models/handpose/. Point modelPath at that
+// model root, not at the tfjs/ or mediapipe/ runtime subfolder.
+
+let handPose;
+let video;
+let hands = [];
+
+function preload() {
+  handPose = ml5.handPose({ modelPath: "./ml5-models/handpose" });
+}
+
+function setup() {
+  createCanvas(640, 480);
+  video = createCapture(VIDEO);
+  video.size(640, 480);
+  video.hide();
+  handPose.detectStart(video, gotHands);
+  console.log("HandPose model loaded from local files.");
+}
+
+function draw() {
+  image(video, 0, 0, width, height);
+  for (let hand of hands) {
+    for (let keypoint of hand.keypoints) {
+      fill(0, 255, 0);
+      noStroke();
+      circle(keypoint.x, keypoint.y, 10);
+    }
+  }
+}
+
+function gotHands(results) {
+  hands = results;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.1",
   "description": "A friendly machine learning library for the web.",
   "main": "dist/ml5.min.js",
+  "bin": {
+    "ml5": "./bin/ml5.js"
+  },
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "webpack --config webpack.config.js --mode production",
@@ -16,7 +19,11 @@
     "update-examples-readme": "node scripts/updateExamplesREADME.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "bin",
+    "cli",
+    "src/utils/modelRegistry.js",
+    "src/utils/modelResolver.js"
   ],
   "keywords": [
     "ML5"

--- a/scripts/generateModelUrlsDoc.js
+++ b/scripts/generateModelUrlsDoc.js
@@ -1,0 +1,57 @@
+// scripts/generateModelUrlsDoc.js
+//
+// STATUS: Placeholder / not yet implemented.
+//
+// PURPOSE
+// -------
+// This script is intended to auto-generate `docs/model-urls.md` from the
+// canonical model registry at `src/utils/modelRegistry.js`, so the human-
+// readable URL reference cannot drift from the URLs ml5 actually requests
+// at runtime.
+//
+// CURRENT STATE
+// -------------
+// `docs/model-urls.md` is hand-maintained today. Five TFJS URLs and the
+// MediaPipe file-list pointer live there. If you change a URL in
+// `src/utils/modelRegistry.js`, you must also update `docs/model-urls.md`
+// by hand. This script does NOT yet enforce that — running it only prints
+// a single line telling you where the docs live.
+//
+// WHY IT IS A STUB
+// ----------------
+// `src/utils/modelRegistry.js` uses ES module `export` syntax and is
+// authored for the browser bundle (consumed by webpack). Importing it
+// directly from a Node CLI script requires one of:
+//   1. Renaming the registry to `.mjs` and adjusting webpack/jest config.
+//   2. Adding a Babel/SWC transform step so this script can `require()` it.
+//   3. Duplicating the URL data in a CommonJS file (rejected — that is
+//      exactly the drift this script is meant to prevent).
+// Option 1 or 2 was out of scope for the initial offline-mode PR (#305).
+//
+// TO IMPLEMENT
+// ------------
+// 1. Pick a transform strategy (recommend option 1: rename to `.mjs` and
+//    update the two or three places that import it).
+// 2. Import `TFJS_MODEL_URLS` and the MediaPipe file lists from the
+//    registry.
+// 3. Render a markdown document matching the current shape of
+//    `docs/model-urls.md` (title, intro, link to manual-setup guide,
+//    bulleted URL list, MediaPipe note).
+// 4. Write the result to `docs/model-urls.md` (use `fs.writeFileSync`).
+// 5. Add a `yarn docs:model-urls` script to `package.json` and wire it
+//    into CI so a drift between registry and docs fails the build.
+//
+// RELATED FILES
+// -------------
+// - src/utils/modelRegistry.js  (source of truth: URLs + MediaPipe files)
+// - docs/model-urls.md          (current hand-written output)
+// - docs/manual-model-setup/where-to-download-models.md (beginner guide)
+//
+// See PR #305 for the offline-mode CLI that consumes the same registry.
+
+console.log(
+  "Model URL documentation lives in docs/model-urls.md and " +
+    "src/utils/modelRegistry.js. This generator is a placeholder; " +
+    "see the header comment in scripts/generateModelUrlsDoc.js for " +
+    "implementation notes."
+);

--- a/src/BodyPose/index.js
+++ b/src/BodyPose/index.js
@@ -27,6 +27,7 @@ import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import objectRenameKey from "../utils/objectRenameKey";
 import { isVideo } from "../utils/handleArguments";
+import { resolveModelUrls } from "../utils/modelResolver";
 
 /**
  * User provided options object for BodyPose with MoveNet model.
@@ -44,6 +45,8 @@ import { isVideo } from "../utils/handleArguments";
  * @property {string} [trackerType]           - The type of tracker to use.
  * @property {object} [trackerConfig]         - Advanced tracker configurations.
  * @property {string} [modelUrl]              - The file path or URL to the MoveNet model.
+ * @property {string|boolean} [modelPath]     - A local model folder, a direct model folder, 'auto',
+ *                                             or false to skip local model auto-detection.
  */
 
 /**
@@ -64,6 +67,8 @@ import { isVideo } from "../utils/handleArguments";
  *                                              model. Only for `tfjs` runtime.
  * @property {string} [landmarkModelUrl]      - The file path or URL to the BlazePose landmark
  *                                              model. Only for `tfjs` runtime.
+ * @property {string|boolean} [modelPath]     - A local model folder, a direct model folder, 'auto',
+ *                                             or false to skip local model auto-detection.
  */
 
 /**
@@ -234,6 +239,13 @@ class BodyPose {
         MoveNetConfigSchema,
         "bodyPose"
       );
+      await tf.ready();
+      await resolveModelUrls({
+        modelName: "bodypose",
+        modelConfig,
+        userOptions: this.userOptions,
+        modelNameForBodyPose: this.modelName,
+      });
       // Map the modelType string to the `movenet.modelType` enum
       switch (modelConfig.modelType) {
         case "SINGLEPOSE_LIGHTNING":
@@ -257,6 +269,14 @@ class BodyPose {
     );
     // Load the TensorFlow.js detector instance
     await tf.ready();
+    if (this.modelName === "BlazePose") {
+      await resolveModelUrls({
+        modelName: "bodypose",
+        modelConfig,
+        userOptions: this.userOptions,
+        modelNameForBodyPose: this.modelName,
+      });
+    }
     this.model = await poseDetection.createDetector(pipeline, modelConfig);
     return this;
   }

--- a/src/FaceMesh/index.js
+++ b/src/FaceMesh/index.js
@@ -26,6 +26,7 @@ import { mediaReady } from "../utils/imageUtilities";
 import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import { UV_COORDS } from "./uv_coords";
+import { resolveModelUrls } from "../utils/modelResolver";
 
 /**
  * User provided options object for FaceMesh. See config schema below for default and available values.
@@ -34,6 +35,8 @@ import { UV_COORDS } from "./uv_coords";
  * @property {boolean} [refineLandmarks]   - Whether to refine the landmarks.
  * @property {boolean} [flipHorizontal]    - Whether to mirror the results.
  * @property {string} [runtime]            - The runtime to use.
+ * @property {string|boolean} [modelPath]  - A local model folder, a direct model folder, 'auto',
+ *                                           or false to skip local model auto-detection.
  * @property {string} [solutionPath]       - The file path or URL to the MediaPipe solution. Only
  *                                           for `mediapipe` runtime.
  * @property {string} [detectorModelUrl]   - The file path or URL to the detector model. Only for
@@ -146,6 +149,11 @@ class FaceMesh {
 
     // Load the model once tfjs is ready
     await tf.ready();
+    await resolveModelUrls({
+      modelName: "facemesh",
+      modelConfig,
+      userOptions: this.userOptions,
+    });
     this.model = await faceLandmarksDetection.createDetector(
       pipeline,
       modelConfig

--- a/src/HandPose/index.js
+++ b/src/HandPose/index.js
@@ -27,6 +27,7 @@ import handleOptions from "../utils/handleOptions";
 import { handleModelName } from "../utils/handleOptions";
 import { mediaReady } from "../utils/imageUtilities";
 import objectRenameKey from "../utils/objectRenameKey";
+import { resolveModelUrls } from "../utils/modelResolver";
 
 /**
  * User provided options object for HandPose. See config schema below for default and available values.
@@ -35,6 +36,8 @@ import objectRenameKey from "../utils/objectRenameKey";
  * @property {string} [modelType]          - The type of model to use.
  * @property {boolean} [flipHorizontal]    - Whether to mirror the landmark results.
  * @property {string} [runtime]            - The runtime of the model.
+ * @property {string|boolean} [modelPath]  - A local model folder, a direct model folder, 'auto',
+ *                                           or false to skip local model auto-detection.
  * @property {string} [solutionPath]       - The file path or URL to mediaPipe solution. Only for
  *                                           `mediapipe` runtime.
  * @property {string} [detectorModelUrl]   - The file path or URL to the hand detector model. Only
@@ -152,6 +155,11 @@ class HandPose {
 
     // Load the Tensorflow.js detector instance
     await tf.ready();
+    await resolveModelUrls({
+      modelName: "handpose",
+      modelConfig,
+      userOptions: this.userOptions,
+    });
     this.model = await handPoseDetection.createDetector(pipeline, modelConfig);
     return this;
   }

--- a/src/utils/modelRegistry.js
+++ b/src/utils/modelRegistry.js
@@ -1,0 +1,146 @@
+export const MODEL_DIRS = {
+  handpose: "handpose",
+  facemesh: "facemesh",
+  bodypose: "bodypose",
+};
+
+export const TFJS_MODEL_PATHS = {
+  handpose: {
+    detectorModelUrl: "tfjs/detector/model.json",
+    landmarkModelUrl: "tfjs/landmark/model.json",
+  },
+  facemesh: {
+    detectorModelUrl: "tfjs/detector/model.json",
+    landmarkModelUrl: "tfjs/landmark/model.json",
+  },
+  bodypose: {
+    modelUrl: "tfjs/model/model.json",
+  },
+  bodyposeBlazepose: {
+    detectorModelUrl: "tfjs/detector/model.json",
+    landmarkModelUrl: "tfjs/landmark/model.json",
+  },
+};
+
+export const TFJS_MODEL_URLS = {
+  handpose: {
+    detectorModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/detector/full/1",
+    landmarkModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/handpose_3d/landmark/full/1",
+  },
+  facemesh: {
+    detectorModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/face_detection/short/1",
+    landmarkModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/face_landmarks_detection/face_mesh/1",
+  },
+  bodypose: {
+    modelUrl: "https://tfhub.dev/google/tfjs-model/movenet/multipose/lightning/1",
+  },
+  bodyposeBlazepose: {
+    detectorModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/detector/1",
+    landmarkModelUrl: "https://tfhub.dev/mediapipe/tfjs-model/blazepose_3d/landmark/full/2",
+  },
+};
+
+export const MEDIAPIPE_MARKER_FILES = {
+  handpose: "hands.binarypb",
+  facemesh: "face_mesh.binarypb",
+  bodypose: "pose_web.binarypb",
+};
+
+export const MEDIAPIPE_PACKAGES = {
+  handpose: {
+    pkg: "@mediapipe/hands",
+    defaultVariant: "full",
+    shared: [
+      "hands.binarypb",
+      "hands.js",
+      "hands_solution_packed_assets.data",
+      "hands_solution_packed_assets_loader.js",
+      "hands_solution_simd_wasm_bin.js",
+      "hands_solution_simd_wasm_bin.wasm",
+      "hands_solution_simd_wasm_bin.data",
+      "hands_solution_wasm_bin.js",
+      "hands_solution_wasm_bin.wasm",
+    ],
+    variants: {
+      lite: ["hand_landmark_lite.tflite"],
+      full: ["hand_landmark_full.tflite"],
+    },
+  },
+  facemesh: {
+    pkg: "@mediapipe/face_mesh",
+    defaultVariant: "default",
+    shared: [
+      "face_mesh.binarypb",
+      "face_mesh.js",
+      "face_mesh_solution_packed_assets.data",
+      "face_mesh_solution_packed_assets_loader.js",
+      "face_mesh_solution_simd_wasm_bin.js",
+      "face_mesh_solution_simd_wasm_bin.wasm",
+      "face_mesh_solution_simd_wasm_bin.data",
+      "face_mesh_solution_wasm_bin.js",
+      "face_mesh_solution_wasm_bin.wasm",
+    ],
+    variants: {
+      default: [],
+    },
+  },
+  bodypose: {
+    pkg: "@mediapipe/pose",
+    defaultVariant: "full",
+    shared: [
+      "pose_web.binarypb",
+      "pose.js",
+      "pose_solution_packed_assets.data",
+      "pose_solution_packed_assets_loader.js",
+      "pose_solution_simd_wasm_bin.js",
+      "pose_solution_simd_wasm_bin.wasm",
+      "pose_solution_simd_wasm_bin.data",
+      "pose_solution_wasm_bin.js",
+      "pose_solution_wasm_bin.wasm",
+    ],
+    variants: {
+      lite: ["pose_landmark_lite.tflite"],
+      full: ["pose_landmark_full.tflite"],
+      heavy: ["pose_landmark_heavy.tflite"],
+    },
+  },
+};
+
+export function getModelDirName(modelName) {
+  return MODEL_DIRS[modelName] || modelName;
+}
+
+export function getMediaPipePackageInfo(modelName) {
+  return MEDIAPIPE_PACKAGES[modelName];
+}
+
+export function getMediaPipeFiles(modelName, variant) {
+  const info = getMediaPipePackageInfo(modelName);
+  if (!info) return [];
+  const resolvedVariant = variant === "all" ? "all" : variant || info.defaultVariant;
+  const variantFiles =
+    resolvedVariant === "all"
+      ? Object.keys(info.variants).flatMap((key) => info.variants[key])
+      : info.variants[resolvedVariant] || info.variants[info.defaultVariant] || [];
+  return [...info.shared, ...variantFiles];
+}
+
+export function getTfjsModelUrls(modelName, options = {}) {
+  if (modelName === "bodypose" && options.modelNameForBodyPose === "BlazePose") {
+    return TFJS_MODEL_URLS.bodyposeBlazepose;
+  }
+  return TFJS_MODEL_URLS[modelName];
+}
+
+export function getTfjsLocalPaths(modelName, options = {}) {
+  if (modelName === "bodypose" && options.modelNameForBodyPose === "BlazePose") {
+    return TFJS_MODEL_PATHS.bodyposeBlazepose;
+  }
+  return TFJS_MODEL_PATHS[modelName];
+}
+
+export function joinUrl(base, path) {
+  const normalizedBase = String(base).replace(/\/+$/, "");
+  const normalizedPath = String(path).replace(/^\/+/, "");
+  return `${normalizedBase}/${normalizedPath}`;
+}

--- a/src/utils/modelResolver.js
+++ b/src/utils/modelResolver.js
@@ -1,0 +1,149 @@
+import {
+  getModelDirName,
+  getTfjsLocalPaths,
+  joinUrl,
+  MEDIAPIPE_MARKER_FILES,
+} from "./modelRegistry";
+
+function canProbe() {
+  return typeof fetch === "function";
+}
+
+async function urlExists(url) {
+  if (!canProbe()) return false;
+  try {
+    const response = await fetch(url, { method: "HEAD" });
+    return response.ok;
+  } catch (error) {
+    return false;
+  }
+}
+
+function getAutoModelRoot(modelName) {
+  return `./ml5-models/${getModelDirName(modelName)}`;
+}
+
+function getTfjsPaths(modelName, modelNameForBodyPose) {
+  return getTfjsLocalPaths(modelName, { modelNameForBodyPose });
+}
+
+function hasExplicitRuntime(userOptions) {
+  return userOptions && Object.prototype.hasOwnProperty.call(userOptions, "runtime");
+}
+
+function supportsRuntimeOption(modelConfig) {
+  return Object.prototype.hasOwnProperty.call(modelConfig, "runtime");
+}
+
+function applyTfjsModelPath(modelConfig, modelName, modelPath, modelNameForBodyPose) {
+  const paths = getTfjsPaths(modelName, modelNameForBodyPose);
+  if (!paths) return;
+  Object.keys(paths).forEach((key) => {
+    modelConfig[key] = joinUrl(modelPath, paths[key]);
+  });
+}
+
+function applyMediaPipeModelPath(modelConfig, modelPath) {
+  modelConfig.solutionPath = joinUrl(modelPath, "mediapipe");
+}
+
+function applyLeafTfjsPath(modelConfig, modelName, modelPath, modelNameForBodyPose) {
+  const paths = getTfjsPaths(modelName, modelNameForBodyPose);
+  if (!paths) return;
+  const keys = Object.keys(paths);
+  if (keys.length === 1) {
+    modelConfig[keys[0]] = joinUrl(modelPath, "model.json");
+  } else {
+    applyTfjsModelPath(modelConfig, modelName, modelPath, modelNameForBodyPose);
+  }
+}
+
+async function resolveExplicitModelPath({ modelName, modelConfig, modelPath, modelNameForBodyPose, userOptions }) {
+  const manifestUrl = joinUrl(modelPath, "manifest.json");
+  const tfjsLeafUrl = joinUrl(modelPath, "model.json");
+  const mediaPipeMarker = MEDIAPIPE_MARKER_FILES[modelName];
+  const mediaPipeMarkerUrl = mediaPipeMarker ? joinUrl(modelPath, mediaPipeMarker) : undefined;
+
+  const [hasManifest, hasTfjsLeaf, hasMediaPipeLeaf] = await Promise.all([
+    urlExists(manifestUrl),
+    urlExists(tfjsLeafUrl),
+    mediaPipeMarkerUrl ? urlExists(mediaPipeMarkerUrl) : Promise.resolve(false),
+  ]);
+
+  if (hasManifest) {
+    if (modelConfig.runtime === "mediapipe" && hasExplicitRuntime(userOptions)) {
+      applyMediaPipeModelPath(modelConfig, modelPath);
+    } else {
+      if (supportsRuntimeOption(modelConfig)) modelConfig.runtime = "tfjs";
+      applyTfjsModelPath(modelConfig, modelName, modelPath, modelNameForBodyPose);
+    }
+    return true;
+  }
+
+  if (hasTfjsLeaf) {
+    if (supportsRuntimeOption(modelConfig)) modelConfig.runtime = "tfjs";
+    applyLeafTfjsPath(modelConfig, modelName, modelPath, modelNameForBodyPose);
+    return true;
+  }
+
+  if (hasMediaPipeLeaf && supportsRuntimeOption(modelConfig)) {
+    modelConfig.runtime = "mediapipe";
+    modelConfig.solutionPath = modelPath;
+    return true;
+  }
+
+  const tried = [`HEAD ${manifestUrl} (ml5 prefetch manifest)`, `HEAD ${tfjsLeafUrl} (raw TFJS model.json)`];
+  if (mediaPipeMarkerUrl) {
+    tried.push(`HEAD ${mediaPipeMarkerUrl} (MediaPipe marker file)`);
+  }
+
+  throw new Error(
+    [
+      `ml5: modelPath '${modelPath}' not reachable for ${modelName}.`,
+      "",
+      "Tried:",
+      ...tried.map((url) => `  - ${url}`),
+      "",
+      `Expected modelPath to point at the model root, for example './ml5-models/${getModelDirName(modelName)}'.`,
+      "Do not point at a runtime subfolder like './ml5-models/handpose/tfjs' or './ml5-models/handpose/mediapipe'.",
+      "",
+      "If you have not staged files yet, run:",
+      `  node bin/ml5.js cache prefetch ${modelName}`,
+      `Once published to npm, this becomes: npx ml5 cache prefetch ${modelName}`,
+    ].join("\n")
+  );
+}
+
+export async function resolveModelUrls({ modelName, modelConfig, userOptions = {}, modelNameForBodyPose }) {
+  const modelPath = userOptions.modelPath;
+
+  if (modelPath === undefined || modelPath === false) {
+    return modelConfig;
+  }
+
+  if (modelPath === "auto") {
+    const autoRoot = getAutoModelRoot(modelName);
+    const manifestUrl = joinUrl(autoRoot, "manifest.json");
+    if (await urlExists(manifestUrl)) {
+      return resolveModelUrls({
+        modelName,
+        modelConfig,
+        userOptions: { ...userOptions, modelPath: autoRoot },
+        modelNameForBodyPose,
+      });
+    }
+    return modelConfig;
+  }
+
+  if (typeof modelPath === "string") {
+    await resolveExplicitModelPath({
+      modelName,
+      modelConfig,
+      modelPath,
+      modelNameForBodyPose,
+      userOptions,
+    });
+  }
+
+  return modelConfig;
+}

--- a/tests/unit/cli/manifest.test.js
+++ b/tests/unit/cli/manifest.test.js
@@ -1,0 +1,27 @@
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { writeManifest, readManifest, verifyManifest } = require("../../../cli/utils/manifest");
+const { sha256File } = require("../../../cli/utils/sha");
+
+describe("CLI manifest utilities", () => {
+  test("writes, reads, and verifies a manifest", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ml5-manifest-"));
+    await fs.mkdir(path.join(dir, "tfjs"));
+    const filePath = path.join(dir, "tfjs", "model.json");
+    await fs.writeFile(filePath, "{}");
+    const stat = await fs.stat(filePath);
+    const manifest = {
+      runtimes: {
+        tfjs: {
+          files: [{ path: "tfjs/model.json", size: stat.size, sha256: await sha256File(filePath) }],
+        },
+      },
+    };
+    await writeManifest(dir, manifest);
+    const read = await readManifest(dir);
+    expect(read.runtimes.tfjs.files).toHaveLength(1);
+    const results = await verifyManifest(dir, read);
+    expect(results[0].ok).toBe(true);
+  });
+});

--- a/tests/unit/modelResolver.test.js
+++ b/tests/unit/modelResolver.test.js
@@ -1,0 +1,39 @@
+import { joinUrl, getMediaPipeFiles } from "../../src/utils/modelRegistry";
+import { resolveModelUrls } from "../../src/utils/modelResolver";
+
+describe("local model registry helpers", () => {
+  test("joinUrl normalizes duplicate slashes at the join boundary", () => {
+    expect(joinUrl("./ml5-models/handpose/", "/tfjs/model/model.json")).toBe(
+      "./ml5-models/handpose/tfjs/model/model.json"
+    );
+  });
+
+  test("MediaPipe manifests include shared and variant assets", () => {
+    const files = getMediaPipeFiles("handpose", "lite");
+    expect(files).toContain("hands.binarypb");
+    expect(files).toContain("hand_landmark_lite.tflite");
+    expect(files).not.toContain("hand_landmark_full.tflite");
+  });
+
+  test("modelPath errors list probed URLs and model root hint", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+
+    await expect(
+      resolveModelUrls({
+        modelName: "handpose",
+        modelConfig: { runtime: "mediapipe" },
+        userOptions: { modelPath: "./ml5-models/handpose/tfjs" },
+      })
+    ).rejects.toThrow(
+      "Expected modelPath to point at the model root, for example './ml5-models/handpose'."
+    );
+
+    await expect(
+      resolveModelUrls({
+        modelName: "handpose",
+        modelConfig: { runtime: "mediapipe" },
+        userOptions: { modelPath: "./ml5-models/handpose/tfjs" },
+      })
+    ).rejects.toThrow("HEAD ./ml5-models/handpose/tfjs/manifest.json");
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds an offline workflow for ml5 models built around two pieces:

1. A new `ml5 cache` CLI (`bin/ml5.js`, `cli/`) that prefetches TFJS and
   MediaPipe model assets into `./ml5-models/` with a SHA-256 manifest.
2. A new `modelPath` runtime option (currently wired into `HandPose`,
   `FaceMesh`, `BodyPose`) that resolves model assets from a local path
   instead of the CDN.

It is intentionally scoped to coexist with #304, not replace it.

## Relationship to #304

#304 introduces an in-browser IndexedDB cache for ml5 model weights
(`cache: true` runtime option). That solves the "second visit is fast and
works offline" problem for end users on the open web.

This PR (#305) solves a different problem: **reproducible, fully offline,
pre-provisioned model assets**, which #304 alone does not cover. Concrete
cases:

- Classroom / workshop machines with no internet, or with strict egress
  filtering that blocks `tfhub.dev` / `storage.googleapis.com` /
  `cdn.jsdelivr.net`.
- CI, kiosks, and offline demos that must not depend on a first-online
  warmup.
- Self-hosted / air-gapped deployments that need to vendor model files
  next to their sketch.
- Users who want to inspect, pin, or check in exact model versions.

The CLI is currently the recommended path for these scenarios because:

- It runs ahead of time, so the first run of the sketch is already offline.
- It produces a versioned, hashable `manifest.json` per model, which makes
  the asset set auditable and verifiable (`ml5 cache verify`).
- It is independent of the browser storage layer, so it does not depend on
  IndexedDB being available, persistent, or unevicted.
- It composes cleanly with `modelPath`, which is a plain runtime option and
  works in any ml5 host environment (p5 web editor with local files,
  bundlers, static hosts, Electron, etc.).

Once #304 lands, the intent is to compose the two: `cache: true` continues
to be the zero-config "just works in the browser" option, and `modelPath` /
the CLI remains the explicit, reproducible option. The resolver in this PR
is structured so a future change can prefer IndexedDB when present and fall
back to `modelPath`, without API changes.

## What's in this PR

**Runtime**
- `src/utils/modelRegistry.js` — canonical TFJS URLs, MediaPipe file lists,
  helpers. Shared source of truth for the runtime.
- `src/utils/modelResolver.js` — `modelPath` resolution with explicit
  probe order: `<path>/manifest.json` → `<path>/model.json` → MediaPipe
  marker (`hands.binarypb` / `face_mesh.binarypb` / `pose_web.binarypb`).
- `HandPose`, `FaceMesh`, `BodyPose` updated to call `resolveModelUrls()`.
- Hardened error message when `modelPath` points at a runtime subfolder
  instead of the model root.

**CLI**
- `bin/ml5.js` — executable shim.
- `cli/index.js` — `cache` subcommand dispatcher.
- `cli/prefetch.js` — orchestration, >30 MB confirmation gate, manifest
  write.
- `cli/registry.js` — CommonJS CLI mirror of the runtime registry.
  *Drift with `src/utils/modelRegistry.js` is intentional for v1 and is
  documented in `cli/README.md` along with the planned follow-up.*
- `cli/{verify,list,models,clear}.js` — supporting subcommands.
- `cli/utils/{download-tfjs,copy-mediapipe,manifest,sha,paths,size,progress}.js`
  — shared helpers. TFJS shard URLs preserve `?tfjs-format=file`. MediaPipe
  assets are copied from `node_modules` with hardcoded filenames and
  dynamically read versions.
- `cli/README.md` — internal architecture map and registry-duplication
  notes.
- Defaults: `--runtime both`, BodyPose MediaPipe variant `full`, BlazePose
  TFJS staged under `bodypose` alongside MoveNet.

**Docs**
- `docs/offline-mode.md` — main offline CLI guide, includes Apache-2.0
  attribution.
- `docs/model-urls.md` — human-readable model URL reference.
- `docs/manual-model-setup/` — six beginner-friendly manual setup docs
  (`README.md`, `where-to-download-models.md`, `troubleshooting.md`,
  `manual-setup-{handpose,facemesh,bodypose}.md`), with a top-of-page
  callout recommending the CLI when Node is available.
- `CONTRIBUTING.md` — `Updating offline model files` section under
  `## Utils`, TOC indentation restored.

**Examples** (model-root form, default to TFJS unless overridden)
- `examples/handPose-keypoints-offline-local-model-cli/`
- `examples/faceMesh-keypoints-offline-local-model-cli/`
- `examples/bodyPose-keypoints-offline-local-model-cli/`

**Tests**
- `tests/unit/modelResolver.test.js` (incl. resolver error-message test).
- `tests/unit/cli/manifest.test.js`.
- `yarn test` → 28 passing, 4 suites.

## Usage

Until this is published to npm, the CLI is invoked via the local shim:

```bash
node bin/ml5.js cache prefetch handpose
node bin/ml5.js cache verify handpose
node bin/ml5.js cache list
```

After publish, the same commands become `npx ml5 cache …`.

In a sketch:

```js
const handPose = ml5.handPose({ modelPath: './ml5-models/handpose' });
```

`modelPath` must point at the **model root** (e.g. `./ml5-models/handpose`),
not at a runtime subfolder like `./ml5-models/handpose/tfjs`.

## Manual setup vs. CLI

`docs/manual-model-setup/` exists as a fallback for environments where
Node isn't available (e.g. Chromebooks, p5 web editor users, locked-down
classroom machines). **If you can run Node, prefer
`npx ml5 cache prefetch` (today: `node bin/ml5.js cache prefetch`).** The
CLI is the recommended path because it:

- Produces the correct on-disk layout automatically.
- Writes a verifiable `manifest.json` with SHA-256 hashes.
- Handles TFJS shard enumeration and MediaPipe asset copying without you
  having to know the filenames.
- Keeps the asset set auditable via `ml5 cache verify`.

The manual path still assumes baseline knowledge that not every beginner
will have:

- Comfort opening a terminal or file explorer to create the folder layout.
- Understanding the difference between TFJS and MediaPipe runtimes and
  why some models need both.
- Knowing how to serve files locally (or use the p5 web editor) so
  `modelPath` resolves over `http(s)://` rather than `file://`.
- Reading and matching the exact filenames (e.g. `model.json` +
  `group1-shard*of*.bin`, MediaPipe `.binarypb` markers).
- Knowing which CDN/version of a file to download — the URLs can change,
  and there's no SHA-256 verification on the manual path.

That's the tradeoff: the manual docs are deliberately simple, but they
push knowledge onto the user that the CLI absorbs. The manual docs now
carry a top-of-page callout recommending the CLI when Node is available.

## Reviewer input requested

The CLI registry (`cli/registry.js`, CommonJS) duplicates the runtime
registry (`src/utils/modelRegistry.js`, ESM). This is intentional for v1
to avoid pulling a build step into `bin/`, but it's a real footgun. The
plan to address it is documented in
[`cli/README.md`](cli/README.md#registry-duplication):

- Short term: a unit test that diffs the two registries and fails CI on
  drift.
- Medium term: generate `cli/registry.js` from `src/utils/modelRegistry.js`
  at build time, or move the shared data into a plain `.json` file
  consumed by both.

Sanity check that this is an acceptable v1 tradeoff before we land.

## Out of scope / follow-ups

- Compose with #304's `cache: true` once it lands (resolver is structured
  for it; no API change needed).
- URL-validation GitHub Action against the registry.
- `-p5-2.0` example variants.
- `BodySegmentation` `modelPath` support.
- More models beyond handpose / facemesh / bodypose (v1 scope is
  intentional).
- Real `docs/model-urls.md` generator (current
  `scripts/generateModelUrlsDoc.js` is a documented placeholder).
- Manual setup guides for the remaining models.
- CLI registry normalization (shared source / generator with
  `src/utils/modelRegistry.js`).
- Downloader retry / User-Agent hardening.
- Hardened shared CLI arg parser (TODOs in `cli/clear.js`,
  `cli/verify.js`).

## Test plan

- [x] `yarn test` (28/28).
- [x] `yarn build` (only pre-existing bundle-size warnings).
- [ ] Browser smoke test for the three offline examples (DevTools Network
      shows local files only).
- [ ] Browser smoke test for the bad-`modelPath` resolver error.
- [ ] Clean-cache smoke: `node bin/ml5.js cache prefetch handpose` →
      `node bin/ml5.js cache verify handpose`.

Marking this **draft** until the browser smoke tests above are run on a
clean checkout and #304 lands so we can confirm the composition story.

Depends on / coexists with: #304