### PR TITLE
Fix iOS WebGPU keypoint misalignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import soundClassifier from "./SoundClassifier";
 import objectDetection from "./ObjectDetection";
 import featureExtractor from "./FeatureExtractor";
 import setBackend from "./utils/setBackend";
+import configureBackend from "./utils/configureBackend";
 import bodySegmentation from "./BodySegmentation";
 import depthEstimation from "./DepthEstimation";
 import communityStatement from "./utils/communityStatement";
@@ -47,6 +48,9 @@ p5Utils.setupP5Integration(
   Object.keys(withPreload),
   Object.keys(withoutAsync)
 );
+
+// Apply ml5's default TensorFlow.js backend configuration (see issue #302).
+configureBackend();
 
 communityStatement();
 

--- a/src/utils/configureBackend.js
+++ b/src/utils/configureBackend.js
@@ -15,6 +15,9 @@ const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
  * The flag is set globally and unconditionally (it only affects the WebGPU
  * backend, so it is harmless when WebGL is active). Safe to call more than once.
  *
+ * Reported upstream as https://github.com/tensorflow/tfjs/issues/8733 — the
+ * workaround can be removed once tf.js (or WebKit) fixes the import path.
+ *
  * @return {void}
  */
 export default function configureBackend() {
@@ -26,12 +29,19 @@ export default function configureBackend() {
     return;
   }
 
-  // Only surface the notice when WebGPU is actually available in the browser,
-  // i.e. when this change can affect the selected backend.
+  // Only surface the notice on iOS / iPadOS with WebGPU available — the
+  // platforms where the misalignment occurs. Elsewhere the flag change is
+  // invisible, and logging it for every WebGPU-capable browser is just noise.
+  // (iPadOS reports itself as "MacIntel", hence the maxTouchPoints check.)
   if (typeof navigator !== "undefined" && navigator.gpu) {
-    console.info(
-      "ml5.js: disabled WebGPU importExternalTexture so video keypoints stay aligned. " +
-        "See https://github.com/ml5js/ml5-next-gen/issues/302"
-    );
+    const isAppleTouchDevice =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    if (isAppleTouchDevice) {
+      console.info(
+        "ml5.js: disabled WebGPU importExternalTexture so video keypoints stay aligned. " +
+          "See https://github.com/ml5js/ml5-next-gen/issues/302"
+      );
+    }
   }
 }

--- a/src/utils/configureBackend.js
+++ b/src/utils/configureBackend.js
@@ -1,0 +1,37 @@
+import * as tf from "@tensorflow/tfjs";
+
+const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
+
+/**
+ * Apply ml5's default TensorFlow.js backend configuration.
+ *
+ * Works around a TensorFlow.js WebGPU bug where video frames imported through
+ * `importExternalTexture` are read with the wrong orientation on iOS / WebKit.
+ * This makes faceMesh, handPose, and bodyPose keypoints appear rotated and
+ * misaligned with the video (ml5 issue #302). Disabling the flag makes the
+ * WebGPU backend copy video frames instead, which keeps keypoints aligned while
+ * preserving the WebGPU backend everywhere else.
+ *
+ * The flag is set globally and unconditionally (it only affects the WebGPU
+ * backend, so it is harmless when WebGL is active). Safe to call more than once.
+ *
+ * @return {void}
+ */
+export default function configureBackend() {
+  try {
+    tf.env().set(WEBGPU_VIDEO_TEXTURE_FLAG, false);
+  } catch (e) {
+    // The WebGPU backend (and therefore the flag) is not present in this
+    // build, so there is nothing to work around.
+    return;
+  }
+
+  // Only surface the notice when WebGPU is actually available in the browser,
+  // i.e. when this change can affect the selected backend.
+  if (typeof navigator !== "undefined" && navigator.gpu) {
+    console.info(
+      "ml5.js: disabled WebGPU importExternalTexture so video keypoints stay aligned. " +
+        "See https://github.com/ml5js/ml5-next-gen/issues/302"
+    );
+  }
+}

--- a/src/utils/configureBackend.js
+++ b/src/utils/configureBackend.js
@@ -12,8 +12,9 @@ const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
  * WebGPU backend copy video frames instead, which keeps keypoints aligned while
  * preserving the WebGPU backend everywhere else.
  *
- * The flag is set globally and unconditionally (it only affects the WebGPU
- * backend, so it is harmless when WebGL is active). Safe to call more than once.
+ * The flag is only set on detected iOS / iPadOS devices, so every other
+ * platform keeps WebGPU's zero-copy `importExternalTexture` path and avoids
+ * the per-frame copy cost. Safe to call more than once.
  *
  * Reported upstream as https://github.com/tensorflow/tfjs/issues/8733 — the
  * workaround can be removed once tf.js (or WebKit) fixes the import path.
@@ -21,6 +22,14 @@ const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
  * @return {void}
  */
 export default function configureBackend() {
+  // iPadOS reports itself as "MacIntel", hence the maxTouchPoints check.
+  const isAppleTouchDevice =
+    typeof navigator !== "undefined" &&
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
+
+  if (!isAppleTouchDevice) return;
+
   try {
     tf.env().set(WEBGPU_VIDEO_TEXTURE_FLAG, false);
   } catch (e) {
@@ -29,19 +38,12 @@ export default function configureBackend() {
     return;
   }
 
-  // Only surface the notice on iOS / iPadOS with WebGPU available — the
-  // platforms where the misalignment occurs. Elsewhere the flag change is
-  // invisible, and logging it for every WebGPU-capable browser is just noise.
-  // (iPadOS reports itself as "MacIntel", hence the maxTouchPoints check.)
-  if (typeof navigator !== "undefined" && navigator.gpu) {
-    const isAppleTouchDevice =
-      /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-    if (isAppleTouchDevice) {
-      console.info(
-        "ml5.js: disabled WebGPU importExternalTexture so video keypoints stay aligned. " +
-          "See https://github.com/ml5js/ml5-next-gen/issues/302"
-      );
-    }
+  // Only log where WebGPU can actually be active — elsewhere the flag change is
+  // invisible and the notice is just noise.
+  if (navigator.gpu) {
+    console.info(
+      "ml5.js: disabled WebGPU importExternalTexture so video keypoints stay aligned. " +
+        "See https://github.com/ml5js/ml5-next-gen/issues/302"
+    );
   }
 }

--- a/tests/unit/configureBackend.test.js
+++ b/tests/unit/configureBackend.test.js
@@ -3,12 +3,42 @@ import configureBackend from "../../src/utils/configureBackend";
 
 const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
 
+const IPHONE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 " +
+  "(KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+const MAC_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 " +
+  "(KHTML, like Gecko) Version/17.5 Safari/605.1.15";
+
 describe("configureBackend", () => {
-  it("forces the WebGPU video-texture flag off when it is registered", () => {
-    // Simulate the WebGPU backend having registered its flag (default: true),
-    // which is what happens once tfjs-backend-webgpu is bundled.
+  const mockedKeys = [];
+
+  // Simulate the WebGPU backend having registered its flag (default: true),
+  // which is what happens once tfjs-backend-webgpu is bundled.
+  beforeAll(() => {
     tf.env().registerFlag(WEBGPU_VIDEO_TEXTURE_FLAG, () => true);
-    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(true);
+  });
+
+  beforeEach(() => {
+    tf.env().set(WEBGPU_VIDEO_TEXTURE_FLAG, true);
+  });
+
+  // `resetMocks` does not undo defineProperty, so remove the mocked own
+  // properties by hand to restore jsdom's defaults.
+  afterEach(() => {
+    while (mockedKeys.length) delete navigator[mockedKeys.pop()];
+  });
+
+  function mockNavigator(props) {
+    Object.entries(props).forEach(([key, value]) => {
+      Object.defineProperty(navigator, key, { value, configurable: true });
+      mockedKeys.push(key);
+    });
+  }
+
+  it("disables the WebGPU video-texture flag on iOS", () => {
+    mockNavigator({ userAgent: IPHONE_USER_AGENT });
 
     configureBackend();
 
@@ -16,8 +46,48 @@ describe("configureBackend", () => {
     expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(false);
   });
 
+  it("disables the flag on iPadOS, which reports a desktop platform", () => {
+    mockNavigator({
+      userAgent: MAC_USER_AGENT,
+      platform: "MacIntel",
+      maxTouchPoints: 5,
+    });
+
+    configureBackend();
+
+    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(false);
+  });
+
+  it("leaves the flag alone off iOS so WebGPU keeps its zero-copy path", () => {
+    configureBackend();
+
+    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(true);
+  });
+
   it("is safe to call again and keeps the flag off", () => {
+    mockNavigator({ userAgent: IPHONE_USER_AGENT });
+
+    configureBackend();
+
     expect(() => configureBackend()).not.toThrow();
     expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(false);
+  });
+
+  it("logs a notice on iOS when WebGPU is available", () => {
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    mockNavigator({ userAgent: IPHONE_USER_AGENT, gpu: {} });
+
+    configureBackend();
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain("importExternalTexture");
+  });
+
+  it("does not log a notice off iOS", () => {
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+
+    configureBackend();
+
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/configureBackend.test.js
+++ b/tests/unit/configureBackend.test.js
@@ -1,0 +1,23 @@
+import * as tf from "@tensorflow/tfjs";
+import configureBackend from "../../src/utils/configureBackend";
+
+const WEBGPU_VIDEO_TEXTURE_FLAG = "WEBGPU_IMPORT_EXTERNAL_TEXTURE";
+
+describe("configureBackend", () => {
+  it("forces the WebGPU video-texture flag off when it is registered", () => {
+    // Simulate the WebGPU backend having registered its flag (default: true),
+    // which is what happens once tfjs-backend-webgpu is bundled.
+    tf.env().registerFlag(WEBGPU_VIDEO_TEXTURE_FLAG, () => true);
+    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(true);
+
+    configureBackend();
+
+    // Keeps faceMesh / handPose / bodyPose keypoints aligned on iOS (#302).
+    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(false);
+  });
+
+  it("is safe to call again and keeps the flag off", () => {
+    expect(() => configureBackend()).not.toThrow();
+    expect(tf.env().getBool(WEBGPU_VIDEO_TEXTURE_FLAG)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #302 — on iOS (iOS 26+, Safari/Chrome), faceMesh and handPose keypoints show up rotated ~90° and out of line with the video. This worked in v1.2.0.

## Why it happens

It's a TF.js backend issue, not ml5's keypoint code (that code didn't change between 1.2.0 and 1.3.1).

ml5 bundles the WebGPU backend, which TF.js picks over WebGL when it's available. On iOS, WebGPU reads video frames with the wrong orientation, so the keypoints come out rotated. In 1.2.0 WebGPU failed to start on iOS and fell back to WebGL, so it looked fine. iOS 26 + the newer TF.js now run WebGPU successfully, which is when the bug shows up.

## The fix

Turn off the `WEBGPU_IMPORT_EXTERNAL_TEXTURE` flag so WebGPU copies video frames instead. Keypoints line up again, and we keep using WebGPU.

- `src/utils/configureBackend.js` (new) — sets the flag
- `src/index.js` — calls it once on load
- `tests/unit/configureBackend.test.js` (new)

Note: this adds a small per-frame copy on all WebGPU devices, including desktop where there's no bug. WebGL is unaffected, and `ml5.setBackend(...)` still works.

## Testing

- iOS 26 (Safari + Chrome): faceMesh and handPose keypoints now line up. 
- `npm test` passes, including the new test.

### Example sketches
- OLD library: https://editor.p5js.org/alanvww/sketches/YRV8Fke5v
- OLD library with forced WebGL: https://editor.p5js.org/alanvww/sketches/KHrvzVgo2
- FIXED library: https://editor.p5js.org/alanvww/sketches/32YR4JF5H

## Update

- Reported upstream as tensorflow/tfjs#8733 (may ultimately be a WebKit `importExternalTexture` bug). The workaround can be removed once that's fixed; the code comment links it.
- The console notice now only logs on iOS/iPadOS with WebGPU available — the platforms actually affected — instead of every WebGPU-capable browser.
- Verified on device: faceMesh and handPose on iOS 26. bodyPose uses the same video input path so it should be equally fixed, but hasn't been device-verified yet — testing welcome.
