### PR TITLE
ImageClassifier: Fix Teachable Machine example

### DIFF
--- a/examples/imageClassifier-teachable-machine/sketch.js
+++ b/examples/imageClassifier-teachable-machine/sketch.js
@@ -18,7 +18,7 @@ let label = "Model loading...";
 let imageModelURL = "https://teachablemachine.withgoogle.com/models/bXy2kDNi/";
 
 async function setup() {
-  classifier = await ml5.imageClassifier("MobileNet");
+  classifier = await ml5.imageClassifier(imageModelURL + "model.json");
   
   createCanvas(640, 480);
 


### PR DESCRIPTION
These examples must have been inadvertently broken during the p5 2.x compatibility changes.

(Spotted while reviewing @colemanliyah's branch)